### PR TITLE
Improve preprocessing utilities and add tests

### DIFF
--- a/core/data/preprocess.py
+++ b/core/data/preprocess.py
@@ -1,20 +1,97 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
 import numpy as np
 import pandas as pd
 
-def normalize_df(df: pd.DataFrame) -> pd.DataFrame:
-    df = df.copy()
-    if "ts" in df: df["ts"] = pd.to_datetime(df["ts"], unit="s", errors="coerce")
-    df = df.sort_values("ts")
-    df = df.drop_duplicates()
-    df = df.interpolate()
-    return df
 
-def scale_series(x, method="zscore"):
-    import numpy as np
-    x = np.asarray(x, dtype=float)
-    if method=="zscore":
-        mu, sd = x.mean(), x.std() + 1e-12
-        return (x-mu)/sd
-    return x
+ArrayLike = np.ndarray | pd.Series | Sequence[float] | Iterable[float]
+
+
+def normalize_df(df: pd.DataFrame, timestamp_col: str = "ts") -> pd.DataFrame:
+    """Return a cleaned and chronologically ordered copy of ``df``.
+
+    The helper performs a defensive copy, standardises the timestamp column
+    (if present) to UTC-aware ``datetime64`` values, sorts the frame by that
+    column, removes duplicate rows and performs linear interpolation on the
+    numeric columns to fill minor gaps.
+
+    Parameters
+    ----------
+    df:
+        Input dataframe to normalise. The original dataframe is never mutated.
+    timestamp_col:
+        Optional name of the column that stores timestamps (defaults to ``"ts"``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        A normalised dataframe with a reset index for predictable downstream
+        usage.
+    """
+
+    normalized = df.copy()
+
+    if timestamp_col in normalized.columns:
+        timestamps = normalized[timestamp_col]
+        if np.issubdtype(timestamps.dtype, np.number):
+            normalized[timestamp_col] = pd.to_datetime(
+                timestamps, unit="s", errors="coerce", utc=True
+            )
+        else:
+            normalized[timestamp_col] = pd.to_datetime(
+                timestamps, errors="coerce", utc=True
+            )
+        normalized = normalized.sort_values(timestamp_col)
+
+    normalized = normalized.drop_duplicates()
+
+    numeric_cols = normalized.select_dtypes(include=["number"]).columns
+    if not numeric_cols.empty:
+        normalized[numeric_cols] = normalized[numeric_cols].interpolate(
+            method="linear", limit_direction="both"
+        )
+
+    return normalized.reset_index(drop=True)
+
+
+def scale_series(x: ArrayLike, method: str = "zscore") -> np.ndarray:
+    """Scale a 1-D array according to the requested ``method``.
+
+    Currently supported scaling methods are ``"zscore"`` (default) and
+    ``"minmax"``. The function always returns a NumPy ``ndarray`` and leaves
+    constant or empty inputs untouched.
+    """
+
+    if isinstance(x, (np.ndarray, pd.Series)):
+        values = np.asarray(x, dtype=float)
+    else:
+        if isinstance(x, (str, bytes)):
+            raise TypeError("scale_series does not support string-like inputs")
+        values = np.asarray(list(x), dtype=float)
+
+    if values.ndim != 1:
+        raise ValueError("scale_series expects a one-dimensional input")
+
+    if values.size == 0:
+        return values
+
+    method = method.lower()
+
+    if method == "zscore":
+        std = values.std()
+        if std == 0:
+            return np.zeros_like(values)
+        mean = values.mean()
+        return (values - mean) / std
+
+    if method == "minmax":
+        data_min = values.min()
+        data_range = values.max() - data_min
+        if data_range == 0:
+            return np.zeros_like(values)
+        return (values - data_min) / data_range
+
+    raise ValueError(f"Unsupported scaling method: {method!r}")

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+root_dir = Path(__file__).resolve().parents[1]
+if str(root_dir) not in sys.path:
+    sys.path.insert(0, str(root_dir))
+
+from core.data.preprocess import normalize_df, scale_series
+
+
+def test_normalize_df_orders_and_interpolates_numeric_columns() -> None:
+    df = pd.DataFrame(
+        {
+            "ts": [3, 1, 2, 1],
+            "value": [np.nan, 2.0, np.nan, 2.0],
+            "label": ["c", "b", "a", "b"],
+        }
+    )
+
+    normalized = normalize_df(df)
+
+    expected_ts = pd.Series(
+        pd.to_datetime([1, 2, 3], unit="s", utc=True), name="ts"
+    )
+    expected_values = pd.Series([2.0, 2.0, 2.0], name="value")
+
+    pd.testing.assert_series_equal(normalized["ts"], expected_ts, check_names=False)
+    pd.testing.assert_series_equal(normalized["value"], expected_values)
+    assert list(normalized["label"]) == ["b", "a", "c"]
+
+
+def test_normalize_df_without_timestamp_column() -> None:
+    df = pd.DataFrame(
+        {
+            "value": [1.0, 1.0, np.nan],
+            "category": ["x", "x", "y"],
+        }
+    )
+
+    normalized = normalize_df(df, timestamp_col="nonexistent")
+
+    pd.testing.assert_index_equal(normalized.index, pd.RangeIndex(0, 2))
+    pd.testing.assert_series_equal(
+        normalized["value"], pd.Series([1.0, 1.0], name="value")
+    )
+    assert list(normalized["category"]) == ["x", "y"]
+
+
+def test_scale_series_zscore_and_minmax() -> None:
+    data = [1.0, 2.0, 3.0]
+
+    z_scaled = scale_series(data, method="zscore")
+    minmax_scaled = scale_series(data, method="minmax")
+
+    np.testing.assert_allclose(z_scaled.mean(), 0.0)
+    np.testing.assert_allclose(z_scaled.std(), 1.0)
+    np.testing.assert_allclose(minmax_scaled, np.array([0.0, 0.5, 1.0]))
+
+
+def test_scale_series_handles_degenerate_inputs() -> None:
+    zeros = np.zeros(5)
+    np.testing.assert_allclose(scale_series(zeros), zeros)
+    np.testing.assert_allclose(scale_series(zeros, method="minmax"), zeros)
+
+
+def test_scale_series_validates_inputs() -> None:
+    with pytest.raises(ValueError):
+        scale_series(np.ones((2, 2)))
+
+    with pytest.raises(ValueError):
+        scale_series([1, 2, 3], method="invalid")
+
+    with pytest.raises(TypeError):
+        scale_series("123")


### PR DESCRIPTION
## Summary
- harden the dataframe normalisation helper with clearer datetime handling, deduplication, and numeric interpolation
- expand the series scaling routine with validation, explicit method support, and robust constant handling
- add regression tests that cover the preprocessing helpers and guard against regressions

## Testing
- pytest tests/test_preprocess.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ec7489848329b4db1b80758a158a