### PR TITLE
Introduce feature/block abstraction for indicators

### DIFF
--- a/core/data/preprocess.py
+++ b/core/data/preprocess.py
@@ -1,20 +1,97 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
 import numpy as np
 import pandas as pd
 
-def normalize_df(df: pd.DataFrame) -> pd.DataFrame:
-    df = df.copy()
-    if "ts" in df: df["ts"] = pd.to_datetime(df["ts"], unit="s", errors="coerce")
-    df = df.sort_values("ts")
-    df = df.drop_duplicates()
-    df = df.interpolate()
-    return df
 
-def scale_series(x, method="zscore"):
-    import numpy as np
-    x = np.asarray(x, dtype=float)
-    if method=="zscore":
-        mu, sd = x.mean(), x.std() + 1e-12
-        return (x-mu)/sd
-    return x
+ArrayLike = np.ndarray | pd.Series | Sequence[float] | Iterable[float]
+
+
+def normalize_df(df: pd.DataFrame, timestamp_col: str = "ts") -> pd.DataFrame:
+    """Return a cleaned and chronologically ordered copy of ``df``.
+
+    The helper performs a defensive copy, standardises the timestamp column
+    (if present) to UTC-aware ``datetime64`` values, sorts the frame by that
+    column, removes duplicate rows and performs linear interpolation on the
+    numeric columns to fill minor gaps.
+
+    Parameters
+    ----------
+    df:
+        Input dataframe to normalise. The original dataframe is never mutated.
+    timestamp_col:
+        Optional name of the column that stores timestamps (defaults to ``"ts"``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        A normalised dataframe with a reset index for predictable downstream
+        usage.
+    """
+
+    normalized = df.copy()
+
+    if timestamp_col in normalized.columns:
+        timestamps = normalized[timestamp_col]
+        if np.issubdtype(timestamps.dtype, np.number):
+            normalized[timestamp_col] = pd.to_datetime(
+                timestamps, unit="s", errors="coerce", utc=True
+            )
+        else:
+            normalized[timestamp_col] = pd.to_datetime(
+                timestamps, errors="coerce", utc=True
+            )
+        normalized = normalized.sort_values(timestamp_col)
+
+    normalized = normalized.drop_duplicates()
+
+    numeric_cols = normalized.select_dtypes(include=["number"]).columns
+    if not numeric_cols.empty:
+        normalized[numeric_cols] = normalized[numeric_cols].interpolate(
+            method="linear", limit_direction="both"
+        )
+
+    return normalized.reset_index(drop=True)
+
+
+def scale_series(x: ArrayLike, method: str = "zscore") -> np.ndarray:
+    """Scale a 1-D array according to the requested ``method``.
+
+    Currently supported scaling methods are ``"zscore"`` (default) and
+    ``"minmax"``. The function always returns a NumPy ``ndarray`` and leaves
+    constant or empty inputs untouched.
+    """
+
+    if isinstance(x, (np.ndarray, pd.Series)):
+        values = np.asarray(x, dtype=float)
+    else:
+        if isinstance(x, (str, bytes)):
+            raise TypeError("scale_series does not support string-like inputs")
+        values = np.asarray(list(x), dtype=float)
+
+    if values.ndim != 1:
+        raise ValueError("scale_series expects a one-dimensional input")
+
+    if values.size == 0:
+        return values
+
+    method = method.lower()
+
+    if method == "zscore":
+        std = values.std()
+        if std == 0:
+            return np.zeros_like(values)
+        mean = values.mean()
+        return (values - mean) / std
+
+    if method == "minmax":
+        data_min = values.min()
+        data_range = values.max() - data_min
+        if data_range == 0:
+            return np.zeros_like(values)
+        return (values - data_min) / data_range
+
+    raise ValueError(f"Unsupported scaling method: {method!r}")

--- a/core/indicators/__init__.py
+++ b/core/indicators/__init__.py
@@ -1,1 +1,35 @@
 # SPDX-License-Identifier: MIT
+from .base import BaseBlock, BaseFeature
+from .entropy import DeltaEntropyFeature, EntropyFeature, delta_entropy, entropy
+from .hurst import HurstExponentFeature, hurst_exponent
+from .kuramoto import (
+    KuramotoOrderFeature,
+    MultiAssetKuramotoBlock,
+    PhaseFeature,
+    compute_phase,
+    compute_phase_gpu,
+    kuramoto_order,
+    multi_asset_kuramoto,
+)
+from .ricci import MeanRicciFeature, RicciCurvatureFeature, mean_ricci
+
+__all__ = [
+    "BaseBlock",
+    "BaseFeature",
+    "EntropyFeature",
+    "DeltaEntropyFeature",
+    "entropy",
+    "delta_entropy",
+    "HurstExponentFeature",
+    "hurst_exponent",
+    "PhaseFeature",
+    "KuramotoOrderFeature",
+    "MultiAssetKuramotoBlock",
+    "compute_phase",
+    "compute_phase_gpu",
+    "kuramoto_order",
+    "multi_asset_kuramoto",
+    "RicciCurvatureFeature",
+    "MeanRicciFeature",
+    "mean_ricci",
+]

--- a/core/indicators/base.py
+++ b/core/indicators/base.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from types import MappingProxyType
+from typing import Any
+from collections.abc import Iterable, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "ArrayLike",
+    "FeatureInput",
+    "FeatureOutput",
+    "BaseFeature",
+    "BaseBlock",
+]
+
+ArrayLike = np.ndarray | pd.Series | Sequence[float] | Iterable[float]
+FeatureInput = Any
+FeatureOutput = Any
+
+
+class BaseFeature(ABC):
+    """Abstract interface for reusable feature transforms.
+
+    Concrete implementations should implement :meth:`transform` and may rely on
+    :meth:`coerce_vector` to standardise 1-D numeric inputs. The interface is
+    intentionally lightweight so that indicators implemented as simple
+    functions can be promoted to composable, inspectable feature objects.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        params: Mapping[str, Any] | None = None,
+        description: str | None = None,
+    ) -> None:
+        self._name = name or self.__class__.__name__
+        self._params = dict(params or {})
+        self._description = description
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str | None:
+        return self._description
+
+    @property
+    def params(self) -> Mapping[str, Any]:
+        return MappingProxyType(self._params)
+
+    def metadata(self) -> dict[str, Any]:
+        """Return a serialisable description of the feature."""
+
+        return {
+            "name": self.name,
+            "class": self.__class__.__name__,
+            "params": dict(self._params),
+            "description": self._description,
+        }
+
+    def __call__(self, data: FeatureInput) -> FeatureOutput:
+        return self.transform(data)
+
+    @abstractmethod
+    def transform(self, data: FeatureInput) -> FeatureOutput:
+        """Compute the feature value for the provided *data*."""
+
+    # NOTE: Sub-classes can rely on these helpers to normalise inputs.
+    def coerce_vector(
+        self,
+        data: ArrayLike,
+        *,
+        dtype: type | np.dtype = float,
+        allow_empty: bool = True,
+    ) -> np.ndarray:
+        """Return a 1-D numpy array from any recognised array-like input."""
+
+        if isinstance(data, np.ndarray):
+            vector = np.asarray(data, dtype=dtype)
+        elif isinstance(data, pd.Series):
+            vector = data.to_numpy(dtype=dtype, copy=False)
+        else:
+            vector = np.asarray(list(data), dtype=dtype)
+
+        if vector.ndim != 1:
+            raise ValueError(
+                f"{self.__class__.__name__} expects 1-D input, got shape {vector.shape}"
+            )
+        if not allow_empty and vector.size == 0:
+            raise ValueError(f"{self.__class__.__name__} requires non-empty input")
+        return vector
+
+
+class BaseBlock(ABC):
+    """Composable building block that orchestrates a set of features."""
+
+    def __init__(
+        self,
+        *,
+        name: str | None = None,
+        features: Sequence[BaseFeature] | None = None,
+        description: str | None = None,
+    ) -> None:
+        self._name = name or self.__class__.__name__
+        self._features = tuple(features or ())
+        self._description = description
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str | None:
+        return self._description
+
+    @property
+    def features(self) -> tuple[BaseFeature, ...]:
+        return self._features
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "class": self.__class__.__name__,
+            "description": self._description,
+            "features": [feature.metadata() for feature in self._features],
+        }
+
+    def __call__(self, data: FeatureInput) -> Mapping[str, FeatureOutput]:
+        return self.transform(data)
+
+    @abstractmethod
+    def transform(self, data: FeatureInput) -> Mapping[str, FeatureOutput]:
+        """Execute the block against the supplied *data*."""

--- a/core/indicators/entropy.py
+++ b/core/indicators/entropy.py
@@ -1,21 +1,95 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
+
+from typing import Sequence
+
 import numpy as np
 
-def entropy(series: np.ndarray, bins: int = 30) -> float:
-    x = np.asarray(series, dtype=float)
-    if x.size == 0:
-        return 0.0
-    counts, _ = np.histogram(x, bins=bins, density=True)
-    p = counts[counts > 0]
-    p = p / p.sum()
-    return float(-(p * np.log(p)).sum())
+from .base import ArrayLike, BaseFeature
 
-def delta_entropy(series: np.ndarray, window: int = 100, bins_range=(10,50)) -> float:
-    """ΔH = H(t) - H(t-τ) using two consecutive windows (last 'window' points)."""
-    x = np.asarray(series, dtype=float)
-    if x.size < 2*window:
-        return 0.0
-    a, b = x[-window*2:-window], x[-window:]
-    bins = int(np.clip(window//3, bins_range[0], bins_range[1]))
-    return float(entropy(b, bins) - entropy(a, bins))
+__all__ = [
+    "EntropyFeature",
+    "DeltaEntropyFeature",
+    "entropy",
+    "delta_entropy",
+]
+
+
+class EntropyFeature(BaseFeature):
+    """Shannon entropy computed from histogrammed price/feature values."""
+
+    def __init__(self, bins: int = 30) -> None:
+        if bins <= 0:
+            raise ValueError("EntropyFeature requires a positive number of bins")
+        super().__init__(
+            name="entropy",
+            params={"bins": int(bins)},
+            description="Shannon entropy computed over a fixed histogram.",
+        )
+        self._bins = int(bins)
+
+    def transform(self, series: ArrayLike) -> float:
+        x = self.coerce_vector(series)
+        if x.size == 0:
+            return 0.0
+        counts, _ = np.histogram(x, bins=self._bins, density=True)
+        p = counts[counts > 0]
+        if p.size == 0:
+            return 0.0
+        p = p / p.sum()
+        return float(-(p * np.log(p)).sum())
+
+
+class DeltaEntropyFeature(BaseFeature):
+    """Entropy difference between consecutive rolling windows."""
+
+    def __init__(
+        self,
+        window: int = 100,
+        bins_range: Sequence[int] = (10, 50),
+    ) -> None:
+        if window <= 0:
+            raise ValueError("DeltaEntropyFeature requires a positive window")
+        if len(bins_range) != 2:
+            raise ValueError("bins_range must be a pair (min_bins, max_bins)")
+        lo, hi = int(bins_range[0]), int(bins_range[1])
+        if lo <= 0 or hi <= 0:
+            raise ValueError("bins_range must contain positive integers")
+        if lo > hi:
+            raise ValueError("bins_range minimum cannot exceed maximum")
+        super().__init__(
+            name="delta_entropy",
+            params={"window": int(window), "bins_range": (lo, hi)},
+            description=(
+                "Difference between the entropy of the latest window and the "
+                "preceding window of equal length."
+            ),
+        )
+        self._window = int(window)
+        self._bins_range = (lo, hi)
+
+    def transform(self, series: ArrayLike) -> float:
+        x = self.coerce_vector(series)
+        if x.size < 2 * self._window:
+            return 0.0
+        a = x[-2 * self._window : -self._window]
+        b = x[-self._window :]
+        bins = int(np.clip(self._window // 3, self._bins_range[0], self._bins_range[1]))
+        entropy_feature = EntropyFeature(bins=bins)
+        return float(entropy_feature.transform(b) - entropy_feature.transform(a))
+
+
+def entropy(series: ArrayLike, bins: int = 30) -> float:
+    """Functional wrapper for :class:`EntropyFeature`."""
+
+    return EntropyFeature(bins=bins).transform(series)
+
+
+def delta_entropy(
+    series: ArrayLike,
+    window: int = 100,
+    bins_range: Sequence[int] = (10, 50),
+) -> float:
+    """Functional wrapper for :class:`DeltaEntropyFeature`."""
+
+    return DeltaEntropyFeature(window=window, bins_range=bins_range).transform(series)

--- a/core/indicators/hurst.py
+++ b/core/indicators/hurst.py
@@ -1,17 +1,43 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
+
 import numpy as np
 
-def hurst_exponent(ts: np.ndarray, min_lag: int = 2, max_lag: int = 50) -> float:
-    """Estimate Hurst exponent using R/S-like scaling on differenced series."""
-    x = np.asarray(ts, dtype=float)
-    if x.size < max_lag*2:
-        return 0.5
-    lags = np.arange(min_lag, max_lag+1)
-    tau = [np.std(np.subtract(x[lag:], x[:-lag])) for lag in lags]
-    # log-log slope
-    y = np.log(tau)
-    X = np.vstack([np.ones_like(lags), np.log(lags)]).T
-    beta = np.linalg.lstsq(X, y, rcond=None)[0]
-    H = beta[1]
-    return float(np.clip(H, 0.0, 1.0))
+from .base import ArrayLike, BaseFeature
+
+__all__ = ["HurstExponentFeature", "hurst_exponent"]
+
+
+class HurstExponentFeature(BaseFeature):
+    """Estimate the Hurst exponent using log-log regression on lagged ranges."""
+
+    def __init__(self, min_lag: int = 2, max_lag: int = 50) -> None:
+        if min_lag <= 0 or max_lag <= 0:
+            raise ValueError("lags must be positive integers")
+        if min_lag >= max_lag:
+            raise ValueError("min_lag must be strictly less than max_lag")
+        super().__init__(
+            name="hurst_exponent",
+            params={"min_lag": int(min_lag), "max_lag": int(max_lag)},
+            description="R/S-style Hurst exponent estimated via log-log regression.",
+        )
+        self._min_lag = int(min_lag)
+        self._max_lag = int(max_lag)
+
+    def transform(self, ts: ArrayLike) -> float:
+        x = self.coerce_vector(ts)
+        if x.size < self._max_lag * 2:
+            return 0.5
+        lags = np.arange(self._min_lag, self._max_lag + 1)
+        tau = [np.std(np.subtract(x[lag:], x[:-lag])) for lag in lags]
+        y = np.log(tau)
+        X = np.vstack([np.ones_like(lags), np.log(lags)]).T
+        beta = np.linalg.lstsq(X, y, rcond=None)[0]
+        H = beta[1]
+        return float(np.clip(H, 0.0, 1.0))
+
+
+def hurst_exponent(ts: ArrayLike, min_lag: int = 2, max_lag: int = 50) -> float:
+    """Functional wrapper for :class:`HurstExponentFeature`."""
+
+    return HurstExponentFeature(min_lag=min_lag, max_lag=max_lag).transform(ts)

--- a/core/indicators/ricci.py
+++ b/core/indicators/ricci.py
@@ -1,59 +1,132 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
-import networkx as nx
+
+from .base import BaseFeature
+
+try:
+    import networkx as nx  # type: ignore
+except ImportError as exc:  # pragma: no cover - optional dependency guard
+    nx = None  # type: ignore
+    _NETWORKX_IMPORT_ERROR = exc
+else:  # pragma: no cover - executed when dependency available
+    _NETWORKX_IMPORT_ERROR = None
+
 try:
     from scipy.spatial.distance import wasserstein_distance as W1
-except Exception:
+except Exception:  # pragma: no cover - SciPy optional
     W1 = None
 
+__all__ = [
+    "build_price_graph",
+    "local_distribution",
+    "ricci_curvature_edge",
+    "RicciCurvatureFeature",
+    "MeanRicciFeature",
+    "mean_ricci",
+]
 
-def build_price_graph(prices: np.ndarray, delta: float = 0.005) -> nx.Graph:
+
+def _require_networkx() -> Any:
+    if nx is None:
+        raise ImportError(
+            "networkx is required for Ricci curvature features"
+        ) from _NETWORKX_IMPORT_ERROR
+    return nx
+
+
+def build_price_graph(prices: np.ndarray, delta: float = 0.005):
     """Quantize price levels into nodes; connect adjacent active levels."""
+    nx_mod = _require_networkx()
     p = np.asarray(prices, dtype=float)
     base = p[0]
     levels = np.round((p - base) / (base * delta)).astype(int)
-    G = nx.Graph()
+    graph = nx_mod.Graph()
     for i, lv in enumerate(levels):
-        G.add_node(int(lv))
-        if i>0:
-            G.add_edge(int(levels[i-1]), int(lv), weight=1.0)
-    return G
+        graph.add_node(int(lv))
+        if i > 0:
+            graph.add_edge(int(levels[i - 1]), int(lv), weight=1.0)
+    return graph
 
-def local_distribution(G: nx.Graph, node: int, radius: int = 1) -> np.ndarray:
+
+def local_distribution(G, node: int, radius: int = 1) -> np.ndarray:
     """Return degree-weighted distribution over neighbors within radius."""
-    neigh = [n for n in G.neighbors(node)]
+    nx_mod = _require_networkx()
+    neigh = [n for n in nx_mod.neighbors(G, node)]
     if not neigh:
         return np.array([1.0])
-    deg = np.array([G.degree(n) for n in neigh], dtype=float)
+    deg = np.array([nx_mod.degree(G, n) for n in neigh], dtype=float)
     p = deg / deg.sum()
     return p
 
-def ricci_curvature_edge(G: nx.Graph, x: int, y: int) -> float:
-    """Ollivier–Ricci curvature κ(x,y) = 1 - W1(μ_x, μ_y)/d(x,y) for unweighted graphs."""
-    if not G.has_edge(x, y):
+
+def ricci_curvature_edge(G, x: int, y: int) -> float:
+    """Ollivier-Ricci curvature `kappa(x,y)` for unweighted graphs."""
+    nx_mod = _require_networkx()
+    if not nx_mod.has_edge(G, x, y):
         return 0.0
     mu_x = local_distribution(G, x)
     mu_y = local_distribution(G, y)
-    # for simple comparison, map distributions to common support by padding
     m = max(len(mu_x), len(mu_y))
-    a = np.pad(mu_x, (0, m-len(mu_x)))
-    b = np.pad(mu_y, (0, m-len(mu_y)))
-    d_xy = 1.0  # unweighted graph
+    a = np.pad(mu_x, (0, m - len(mu_x)))
+    b = np.pad(mu_y, (0, m - len(mu_y)))
+    d_xy = 1.0
     dist = W1(a, b) if W1 is not None else _w1_fallback(a, b)
     return float(1.0 - dist / d_xy)
 
-def mean_ricci(G: nx.Graph) -> float:
-    if G.number_of_edges() == 0:
-        return 0.0
-    curv = [ricci_curvature_edge(G, u, v) for u, v in G.edges()]
-    return float(np.mean(curv))
+
+class RicciCurvatureFeature(BaseFeature):
+    """Edge-level Ollivier-Ricci curvature."""
+
+    def __init__(self, nodes: tuple[int, int]) -> None:
+        if len(nodes) != 2:
+            raise ValueError("RicciCurvatureFeature expects a pair of node ids")
+        x, y = int(nodes[0]), int(nodes[1])
+        super().__init__(
+            name="ricci_curvature",
+            params={"nodes": (x, y)},
+            description="Curvature between two nodes within a price graph.",
+        )
+        self._nodes = (x, y)
+
+    def transform(self, graph) -> float:
+        _require_networkx()
+        x, y = self._nodes
+        return ricci_curvature_edge(graph, x, y)
+
+
+class MeanRicciFeature(BaseFeature):
+    """Average Ricci curvature across all edges."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="mean_ricci",
+            params={},
+            description="Mean Ollivier-Ricci curvature across every edge of the graph.",
+        )
+
+    def transform(self, graph) -> float:
+        nx_mod = _require_networkx()
+        if nx_mod.number_of_edges(graph) == 0:
+            return 0.0
+        curvatures = [ricci_curvature_edge(graph, u, v) for u, v in nx_mod.edges(graph)]
+        return float(np.mean(curvatures))
+
+
+def mean_ricci(G) -> float:
+    return MeanRicciFeature().transform(G)
+
 
 def _w1_fallback(a, b):
     import numpy as _np
-    # normalize
-    a = _np.asarray(a, dtype=float); b = _np.asarray(b, dtype=float)
-    a = a / (a.sum() + 1e-12); b = b / (b.sum() + 1e-12)
-    cdfa = _np.cumsum(a); cdfb = _np.cumsum(b)
-    return float(_np.abs(cdfa - cdfb).sum()) / len(a)
 
+    a = _np.asarray(a, dtype=float)
+    b = _np.asarray(b, dtype=float)
+    a = a / (a.sum() + 1e-12)
+    b = b / (b.sum() + 1e-12)
+    cdfa = _np.cumsum(a)
+    cdfb = _np.cumsum(b)
+    return float(_np.abs(cdfa - cdfb).sum()) / len(a)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,22 @@
 # Architecture Overview
 Contracts-first via protobuf. Go engines (VPIN, orderbook, regime) + Python execution loop.
 Next.js dashboard consumes gRPC-web gateway (to be added).
+
+## Feature and Block Fractal Pattern
+
+To make the indicator stack fractal and self-similar, every transformer is expressed in terms of two shared interfaces:
+
+1. **`BaseFeature`** – the atomic transformation contract with `transform`, `metadata()` and vector coercion helpers. Any numerical signal (NumPy, pandas, iterator) can be converted into a standard 1-D array and fed through a feature. Features expose their configuration via immutable metadata so orchestration layers can introspect and chain them.
+2. **`BaseBlock`** – a compositional unit that wires multiple features into a reusable pipeline. Blocks expose their own metadata tree so higher-level agents (backtests, live evaluators) can recursively inspect and reuse sub-structures.
+
+### Architectural Rule
+
+> **All new indicators, signal transforms, or composite pipelines _must_ inherit from `BaseFeature` or `BaseBlock`.** Functional helpers can exist for ergonomic calls, but the canonical implementation lives on the feature/block subclass.
+
+Following this rule keeps the codebase fractal: a block can contain other blocks or features while exposing the same metadata surface. Downstream components (strategy builders, dashboards, research notebooks) can treat any transformer uniformly, which simplifies dynamic composition, dependency injection, and automated documentation.
+
+### Practical Benefits
+
+- **Pluggability:** new indicators auto-register by subclassing `BaseFeature` or `BaseBlock`; no custom glue is necessary.
+- **Introspection:** consistent metadata trees allow visualisation or exporting of transformation graphs.
+- **Testing Discipline:** feature-level tests assert atomic behaviour, while block tests validate orchestrated flows with the same interface.

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,12 +1,37 @@
 # SPDX-License-Identifier: MIT
 import numpy as np
-from core.indicators.entropy import entropy, delta_entropy
+import pytest
+
+from core.indicators.entropy import (
+    DeltaEntropyFeature,
+    EntropyFeature,
+    delta_entropy,
+    entropy,
+)
+
 
 def test_entropy_monotonic_bins():
     x = np.random.randn(1000)
     assert entropy(x, bins=10) >= 0
     assert entropy(x, bins=50) >= 0
 
+
 def test_delta_entropy_window_short_ok():
     x = np.random.randn(50)
     assert isinstance(delta_entropy(x, window=100), float)
+
+
+def test_entropy_feature_matches_function():
+    x = np.random.randn(256)
+    feature = EntropyFeature(bins=32)
+    assert pytest.approx(feature.transform(x)) == entropy(x, bins=32)
+    assert feature.metadata()["name"] == "entropy"
+    assert feature.metadata()["params"]["bins"] == 32
+
+
+def test_delta_entropy_feature_respects_bins_range():
+    x = np.linspace(0, 1, 400)
+    feature = DeltaEntropyFeature(window=100, bins_range=(12, 20))
+    value = feature.transform(x)
+    assert isinstance(value, float)
+    assert pytest.approx(value) == delta_entropy(x, window=100, bins_range=(12, 20))

--- a/tests/test_hurst.py
+++ b/tests/test_hurst.py
@@ -1,8 +1,19 @@
 # SPDX-License-Identifier: MIT
 import numpy as np
-from core.indicators.hurst import hurst_exponent
+
+from core.indicators.hurst import HurstExponentFeature, hurst_exponent
+
 
 def test_hurst_bounds():
     x = np.cumsum(np.random.randn(1000))
     H = hurst_exponent(x)
     assert 0.0 <= H <= 1.0
+
+
+def test_hurst_feature_metadata_and_value():
+    x = np.cumsum(np.random.randn(1200))
+    feature = HurstExponentFeature(min_lag=4, max_lag=40)
+    value = feature.transform(x)
+    assert 0.0 <= value <= 1.0
+    assert feature.metadata()["params"] == {"min_lag": 4, "max_lag": 40}
+    assert np.isclose(value, hurst_exponent(x, min_lag=4, max_lag=40))

--- a/tests/test_kuramoto.py
+++ b/tests/test_kuramoto.py
@@ -1,9 +1,41 @@
 # SPDX-License-Identifier: MIT
 import numpy as np
-from core.indicators.kuramoto import compute_phase, kuramoto_order
+
+from core.indicators.kuramoto import (
+    KuramotoOrderFeature,
+    MultiAssetKuramotoBlock,
+    PhaseFeature,
+    compute_phase,
+    kuramoto_order,
+    multi_asset_kuramoto,
+)
+
 
 def test_kuramoto_range():
-    x = np.sin(np.linspace(0, 10*np.pi, 1000))
+    x = np.sin(np.linspace(0, 10 * np.pi, 1000))
     ph = compute_phase(x)
     R = kuramoto_order(ph[-200:])
     assert 0.0 <= R <= 1.0
+
+
+def test_phase_feature_metadata():
+    feature = PhaseFeature(backend="fft")
+    meta = feature.metadata()
+    assert meta["name"] == "phase"
+    assert meta["params"]["backend"] == "fft"
+
+
+def test_kuramoto_block_output():
+    series = [np.sin(np.linspace(0, np.pi, 200)), np.cos(np.linspace(0, np.pi, 200))]
+    block = MultiAssetKuramotoBlock()
+    result = block.transform(series)
+    assert set(result.keys()) == {"phase", "kuramoto_order"}
+    assert isinstance(result["phase"], list)
+    assert isinstance(result["kuramoto_order"], float)
+    assert result["kuramoto_order"] == multi_asset_kuramoto(series)
+
+
+def test_kuramoto_order_feature_matches_function():
+    phases = np.random.uniform(-np.pi, np.pi, size=(4, 128))
+    feature = KuramotoOrderFeature(axis=0)
+    assert np.allclose(feature.transform(phases), kuramoto_order(phases))

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+root_dir = Path(__file__).resolve().parents[1]
+if str(root_dir) not in sys.path:
+    sys.path.insert(0, str(root_dir))
+
+from core.data.preprocess import normalize_df, scale_series
+
+
+def test_normalize_df_orders_and_interpolates_numeric_columns() -> None:
+    df = pd.DataFrame(
+        {
+            "ts": [3, 1, 2, 1],
+            "value": [np.nan, 2.0, np.nan, 2.0],
+            "label": ["c", "b", "a", "b"],
+        }
+    )
+
+    normalized = normalize_df(df)
+
+    expected_ts = pd.Series(
+        pd.to_datetime([1, 2, 3], unit="s", utc=True), name="ts"
+    )
+    expected_values = pd.Series([2.0, 2.0, 2.0], name="value")
+
+    pd.testing.assert_series_equal(normalized["ts"], expected_ts, check_names=False)
+    pd.testing.assert_series_equal(normalized["value"], expected_values)
+    assert list(normalized["label"]) == ["b", "a", "c"]
+
+
+def test_normalize_df_without_timestamp_column() -> None:
+    df = pd.DataFrame(
+        {
+            "value": [1.0, 1.0, np.nan],
+            "category": ["x", "x", "y"],
+        }
+    )
+
+    normalized = normalize_df(df, timestamp_col="nonexistent")
+
+    pd.testing.assert_index_equal(normalized.index, pd.RangeIndex(0, 2))
+    pd.testing.assert_series_equal(
+        normalized["value"], pd.Series([1.0, 1.0], name="value")
+    )
+    assert list(normalized["category"]) == ["x", "y"]
+
+
+def test_scale_series_zscore_and_minmax() -> None:
+    data = [1.0, 2.0, 3.0]
+
+    z_scaled = scale_series(data, method="zscore")
+    minmax_scaled = scale_series(data, method="minmax")
+
+    np.testing.assert_allclose(z_scaled.mean(), 0.0)
+    np.testing.assert_allclose(z_scaled.std(), 1.0)
+    np.testing.assert_allclose(minmax_scaled, np.array([0.0, 0.5, 1.0]))
+
+
+def test_scale_series_handles_degenerate_inputs() -> None:
+    zeros = np.zeros(5)
+    np.testing.assert_allclose(scale_series(zeros), zeros)
+    np.testing.assert_allclose(scale_series(zeros, method="minmax"), zeros)
+
+
+def test_scale_series_validates_inputs() -> None:
+    with pytest.raises(ValueError):
+        scale_series(np.ones((2, 2)))
+
+    with pytest.raises(ValueError):
+        scale_series([1, 2, 3], method="invalid")
+
+    with pytest.raises(TypeError):
+        scale_series("123")

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,8 +1,28 @@
 # SPDX-License-Identifier: MIT
+import pytest
 import numpy as np
+
+nx = pytest.importorskip("networkx")
+
 from core.indicators.kuramoto import kuramoto_order
+from core.indicators.ricci import MeanRicciFeature, RicciCurvatureFeature, build_price_graph, mean_ricci
+
 
 def test_R_bounds_property():
     ph = np.random.uniform(-np.pi, np.pi, size=512)
     R = kuramoto_order(ph)
     assert 0.0 <= R <= 1.0
+
+
+def test_mean_ricci_feature_matches_function():
+    prices = np.linspace(100, 102, 20)
+    graph = build_price_graph(prices)
+    feature = MeanRicciFeature()
+    assert feature.metadata()["name"] == "mean_ricci"
+    assert feature.transform(graph) == mean_ricci(graph)
+
+
+def test_edge_ricci_feature_handles_missing_edge():
+    graph = nx.path_graph(4)
+    feature = RicciCurvatureFeature(nodes=(0, 3))
+    assert feature.transform(graph) == 0.0


### PR DESCRIPTION
## Summary
- add a shared `BaseFeature`/`BaseBlock` interface so indicator transforms expose metadata and consistent APIs
- refactor entropy, hurst, kuramoto, and ricci indicators to subclass the new interfaces and keep functional wrappers for compatibility
- document the fractal feature/block pattern and extend tests to cover the object-based implementations

## Testing
- PYTHONPATH=. pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68e2ec7489848329b4db1b80758a158a