### PR TITLE
test: maximize indicator coverage and add ci checks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,31 @@
+name: CI Tests
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run pytest with coverage
+        run: pytest --cov=core/indicators --cov-report=term-missing --cov-report=xml

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/analytics/fpma/__init__.py
+++ b/analytics/fpma/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/analytics/fpma/tests/__init__.py
+++ b/analytics/fpma/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/analytics/fpma/tests/test_core.py
+++ b/analytics/fpma/tests/test_core.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: MIT
-from src.core import main
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from analytics.fpma.src.core import main
 
 def test_add():
     assert main.add(2,3)==5

--- a/analytics/regime/__init__.py
+++ b/analytics/regime/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/analytics/regime/tests/__init__.py
+++ b/analytics/regime/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/analytics/regime/tests/test_core.py
+++ b/analytics/regime/tests/test_core.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: MIT
-from src.core import main
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from analytics.regime.src.core import main
 
 def test_add():
     assert main.add(2,3)==5

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+"""Pytest fixtures and environment setup."""
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/core/indicators/__init__.py
+++ b/core/indicators/__init__.py
@@ -1,1 +1,41 @@
 # SPDX-License-Identifier: MIT
+"""Indicator package exports."""
+
+from .base import BaseBlock, BaseFeature, FeatureBlock, FeatureResult, FunctionalFeature
+from .entropy import DeltaEntropyFeature, EntropyFeature, delta_entropy, entropy
+from .hurst import HurstFeature, hurst_exponent
+from .kuramoto import (
+    KuramotoOrderFeature,
+    MultiAssetKuramotoFeature,
+    compute_phase,
+    compute_phase_gpu,
+    kuramoto_order,
+    multi_asset_kuramoto,
+)
+from .ricci import MeanRicciFeature, build_price_graph, local_distribution, mean_ricci, ricci_curvature_edge
+
+__all__ = [
+    "BaseBlock",
+    "BaseFeature",
+    "FeatureBlock",
+    "FeatureResult",
+    "FunctionalFeature",
+    "entropy",
+    "delta_entropy",
+    "EntropyFeature",
+    "DeltaEntropyFeature",
+    "hurst_exponent",
+    "HurstFeature",
+    "compute_phase",
+    "compute_phase_gpu",
+    "kuramoto_order",
+    "multi_asset_kuramoto",
+    "KuramotoOrderFeature",
+    "MultiAssetKuramotoFeature",
+    "build_price_graph",
+    "local_distribution",
+    "ricci_curvature_edge",
+    "mean_ricci",
+    "MeanRicciFeature",
+]
+

--- a/core/indicators/base.py
+++ b/core/indicators/base.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+"""Foundational feature/block interfaces for indicator transformers.
+
+These contracts make the fractal composition of indicators explicit: every
+feature exposes the same `transform` signature and every block orchestrates a
+homogeneous list of features.  Any new indicator can therefore be plugged into
+an existing block (or nested block) without bespoke glue code.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Mapping, MutableSequence, Sequence
+
+FeatureInput = Any
+
+
+@dataclass(slots=True)
+class FeatureResult:
+    """Canonical payload returned by every feature transformer."""
+
+    name: str
+    value: Any
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class BaseFeature(ABC):
+    """Structural contract for every indicator/feature transformer."""
+
+    def __init__(self, name: str | None = None) -> None:
+        self.name = name or self.__class__.__name__
+
+    def __call__(self, data: FeatureInput, **kwargs: Any) -> FeatureResult:
+        return self.transform(data, **kwargs)
+
+    @abstractmethod
+    def transform(self, data: FeatureInput, **kwargs: Any) -> FeatureResult:
+        """Produce a feature result from raw input."""
+
+
+class BaseBlock(ABC):
+    """Composable container that orchestrates a homogeneous list of features."""
+
+    def __init__(
+        self,
+        features: Sequence[BaseFeature] | None = None,
+        *,
+        name: str | None = None,
+    ) -> None:
+        self.name = name or self.__class__.__name__
+        self._features: MutableSequence[BaseFeature] = list(features or [])
+
+    @property
+    def features(self) -> tuple[BaseFeature, ...]:
+        return tuple(self._features)
+
+    def register(self, feature: BaseFeature) -> None:
+        self._features.append(feature)
+
+    def extend(self, features: Iterable[BaseFeature]) -> None:
+        self._features.extend(features)
+
+    def __call__(self, data: FeatureInput, **kwargs: Any) -> Mapping[str, Any]:
+        return self.run(data, **kwargs)
+
+    @abstractmethod
+    def run(self, data: FeatureInput, **kwargs: Any) -> Mapping[str, Any]:
+        """Execute the block over the input and return a feature mapping."""
+
+
+class FeatureBlock(BaseBlock):
+    """Minimal block that executes its child features sequentially."""
+
+    def run(self, data: FeatureInput, **kwargs: Any) -> Mapping[str, Any]:
+        outputs: dict[str, Any] = {}
+        for feature in self.features:
+            result = feature.transform(data, **kwargs)
+            outputs[result.name] = result.value
+        return outputs
+
+
+class FunctionalFeature(BaseFeature):
+    """Adapter that wraps a plain function into the feature interface."""
+
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        *,
+        name: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(name)
+        self._func = func
+        self._metadata = dict(metadata or {})
+
+    def transform(self, data: FeatureInput, **kwargs: Any) -> FeatureResult:
+        value = self._func(data, **kwargs)
+        return FeatureResult(name=self.name, value=value, metadata=self._metadata)
+
+
+__all__ = [
+    "BaseFeature",
+    "BaseBlock",
+    "FeatureBlock",
+    "FunctionalFeature",
+    "FeatureResult",
+]
+

--- a/core/indicators/entropy.py
+++ b/core/indicators/entropy.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
+
+from .base import BaseFeature, FeatureResult
+
 
 def entropy(series: np.ndarray, bins: int = 30) -> float:
     x = np.asarray(series, dtype=float)
@@ -11,11 +17,52 @@ def entropy(series: np.ndarray, bins: int = 30) -> float:
     p = p / p.sum()
     return float(-(p * np.log(p)).sum())
 
-def delta_entropy(series: np.ndarray, window: int = 100, bins_range=(10,50)) -> float:
+
+def delta_entropy(series: np.ndarray, window: int = 100, bins_range=(10, 50)) -> float:
     """ΔH = H(t) - H(t-τ) using two consecutive windows (last 'window' points)."""
     x = np.asarray(series, dtype=float)
-    if x.size < 2*window:
+    if x.size < 2 * window:
         return 0.0
-    a, b = x[-window*2:-window], x[-window:]
-    bins = int(np.clip(window//3, bins_range[0], bins_range[1]))
+    a, b = x[-window * 2 : -window], x[-window:]
+    bins = int(np.clip(window // 3, bins_range[0], bins_range[1]))
     return float(entropy(b, bins) - entropy(a, bins))
+
+
+class EntropyFeature(BaseFeature):
+    """Feature wrapper around the Shannon entropy indicator."""
+
+    def __init__(self, bins: int = 30, *, name: str | None = None) -> None:
+        super().__init__(name or "entropy")
+        self.bins = bins
+
+    def transform(self, data: np.ndarray, **_: Any) -> FeatureResult:
+        value = entropy(data, bins=self.bins)
+        return FeatureResult(name=self.name, value=value, metadata={"bins": self.bins})
+
+
+class DeltaEntropyFeature(BaseFeature):
+    """Feature that computes ΔH over a rolling window."""
+
+    def __init__(
+        self,
+        window: int = 100,
+        bins_range: tuple[int, int] = (10, 50),
+        *,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name or "delta_entropy")
+        self.window = window
+        self.bins_range = bins_range
+
+    def transform(self, data: np.ndarray, **_: Any) -> FeatureResult:
+        value = delta_entropy(data, window=self.window, bins_range=self.bins_range)
+        metadata = {"window": self.window, "bins_range": self.bins_range}
+        return FeatureResult(name=self.name, value=value, metadata=metadata)
+
+
+__all__ = [
+    "entropy",
+    "delta_entropy",
+    "EntropyFeature",
+    "DeltaEntropyFeature",
+]

--- a/core/indicators/hurst.py
+++ b/core/indicators/hurst.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
+
+from .base import BaseFeature, FeatureResult
+
 
 def hurst_exponent(ts: np.ndarray, min_lag: int = 2, max_lag: int = 50) -> float:
     """Estimate Hurst exponent using R/S-like scaling on differenced series."""
     x = np.asarray(ts, dtype=float)
-    if x.size < max_lag*2:
+    if x.size < max_lag * 2:
         return 0.5
-    lags = np.arange(min_lag, max_lag+1)
+    lags = np.arange(min_lag, max_lag + 1)
     tau = [np.std(np.subtract(x[lag:], x[:-lag])) for lag in lags]
     # log-log slope
     y = np.log(tau)
@@ -15,3 +21,26 @@ def hurst_exponent(ts: np.ndarray, min_lag: int = 2, max_lag: int = 50) -> float
     beta = np.linalg.lstsq(X, y, rcond=None)[0]
     H = beta[1]
     return float(np.clip(H, 0.0, 1.0))
+
+
+class HurstFeature(BaseFeature):
+    """Feature wrapper for the Hurst exponent estimate."""
+
+    def __init__(
+        self,
+        min_lag: int = 2,
+        max_lag: int = 50,
+        *,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name or "hurst_exponent")
+        self.min_lag = min_lag
+        self.max_lag = max_lag
+
+    def transform(self, data: np.ndarray, **_: Any) -> FeatureResult:
+        value = hurst_exponent(data, min_lag=self.min_lag, max_lag=self.max_lag)
+        metadata = {"min_lag": self.min_lag, "max_lag": self.max_lag}
+        return FeatureResult(name=self.name, value=value, metadata=metadata)
+
+
+__all__ = ["hurst_exponent", "HurstFeature"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,21 @@
 # Architecture Overview
 Contracts-first via protobuf. Go engines (VPIN, orderbook, regime) + Python execution loop.
 Next.js dashboard consumes gRPC-web gateway (to be added).
+
+## Indicator/Feature Fractal Pattern
+
+To make the "fractal" composition of indicators explicit, every transformer now
+follows two canonical interfaces:
+
+- `BaseFeature`: single, pure transformer that turns raw input into a
+  `FeatureResult` (value + metadata). All quantitative indicators inherit from
+  this base, so a new indicator only needs to implement `transform(...)`.
+- `BaseBlock`: container that orchestrates homogeneous features. The concrete
+  `FeatureBlock` simply loops over registered features and merges their outputs,
+  but blocks can themselves be nested, giving the repeating structure the
+  methodology requires.
+
+Any future indicator/alpha block that respects these contracts can be dropped
+into higher-level orchestrations (phase detector, policy router, dashboards)
+without additional glue code. This rule is now part of the architecture
+checklist alongside protobuf contracts and gRPC integration.

--- a/docs/indicators.md
+++ b/docs/indicators.md
@@ -4,3 +4,11 @@
 - Shannon entropy H and ΔH
 - Hurst exponent
 - Ricci curvature (graph-based)
+
+## Fractal feature/block pattern
+
+All indicators implement the `BaseFeature` interface and can be registered in a
+`FeatureBlock`. Blocks can host features or other blocks, so indicator
+pipelines (phase → regime → policy) repeat the same contract at every level.
+This keeps the fractal structure explicit: adding a new indicator only requires
+defining `transform(...)` and (optionally) plugging it into an existing block.

--- a/markets/__init__.py
+++ b/markets/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/markets/orderbook/__init__.py
+++ b/markets/orderbook/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/markets/orderbook/tests/__init__.py
+++ b/markets/orderbook/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/markets/orderbook/tests/test_core.py
+++ b/markets/orderbook/tests/test_core.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: MIT
-from src.core import main
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from markets.orderbook.src.core import main
 
 def test_add():
     assert main.add(2,3)==5

--- a/markets/vpin/__init__.py
+++ b/markets/vpin/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/markets/vpin/tests/__init__.py
+++ b/markets/vpin/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/markets/vpin/tests/test_core.py
+++ b/markets/vpin/tests/test_core.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: MIT
-from src.core import main
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from markets.vpin.src.core import main
 
 def test_add():
     assert main.add(2,3)==5

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: MIT
 [pytest]
 addopts = -q -ra --maxfail=1 -W error::DeprecationWarning
-testpaths = domains
 python_files = test_*.py
+testpaths =
+    tests
+    analytics
+    markets
+    core
+asyncio_default_fixture_loop_scope = function
 filterwarnings =
     ignore::UserWarning
+    ignore:.*asyncio_default_fixture_loop_scope.*:pytest.PytestDeprecationWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ black==24.8.0
 ruff==0.6.9
 mypy==1.11.2
 pytest==8.3.3
+pytest-cov==5.0.0
 pytest-asyncio==0.24.0
 bandit==1.7.9

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,12 +1,54 @@
 # SPDX-License-Identifier: MIT
+import pathlib
+import sys
+
 import numpy as np
-from core.indicators.entropy import entropy, delta_entropy
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.indicators.base import FeatureBlock
+from core.indicators.entropy import (
+    DeltaEntropyFeature,
+    EntropyFeature,
+    delta_entropy,
+    entropy,
+)
+
 
 def test_entropy_monotonic_bins():
     x = np.random.randn(1000)
     assert entropy(x, bins=10) >= 0
     assert entropy(x, bins=50) >= 0
 
+
+def test_entropy_returns_zero_for_empty_input():
+    assert entropy(np.array([])) == 0.0
+
+
 def test_delta_entropy_window_short_ok():
     x = np.random.randn(50)
-    assert isinstance(delta_entropy(x, window=100), float)
+    assert delta_entropy(x, window=100) == 0.0
+
+
+def test_delta_entropy_feature_metadata():
+    x = np.random.randn(512)
+    feature = DeltaEntropyFeature(window=64, bins_range=(8, 32))
+    result = feature(x)
+    assert result.metadata == {"window": 64, "bins_range": (8, 32)}
+
+
+def test_entropy_feature_custom_name_and_metadata():
+    x = np.random.randn(400)
+    feature = EntropyFeature(bins=20, name="entropy_signal")
+    result = feature(x)
+    assert result.name == "entropy_signal"
+    assert result.metadata == {"bins": 20}
+
+
+def test_entropy_feature_block_interface():
+    x = np.random.randn(400)
+    block = FeatureBlock([EntropyFeature(bins=20), DeltaEntropyFeature(window=100)])
+    result = block(x)
+    assert set(result.keys()) == {"entropy", "delta_entropy"}

--- a/tests/test_features_base.py
+++ b/tests/test_features_base.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.indicators.base import (
+    BaseFeature,
+    FeatureBlock,
+    FeatureResult,
+    FunctionalFeature,
+)
+
+
+class _SquareFeature(BaseFeature):
+    def __init__(self, *, name: str | None = None) -> None:
+        super().__init__(name or "square")
+
+    def transform(self, data, **_: object) -> FeatureResult:
+        value = float(np.asarray(data).mean()) ** 2
+        return FeatureResult(name=self.name, value=value, metadata={"op": "square"})
+
+
+class _IdentityFeature(BaseFeature):
+    def __init__(self, *, name: str | None = None) -> None:
+        super().__init__(name)
+
+    def transform(self, data, **_: object) -> FeatureResult:
+        return FeatureResult(name=self.name, value=data, metadata={})
+
+
+def test_feature_result_defaults_to_empty_metadata():
+    result = FeatureResult(name="foo", value=1.0)
+    assert result.metadata == {}
+
+
+def test_base_feature_call_delegates_to_transform():
+    feature = _SquareFeature()
+    out = feature(np.array([1.0, 3.0]))
+    assert pytest.approx(out.value, rel=1e-9) == 4.0
+    assert out.metadata["op"] == "square"
+
+
+def test_feature_block_register_and_extend_executes_all():
+    block = FeatureBlock(
+        [
+            FunctionalFeature(sum, name="sum", metadata={"units": "raw"}),
+        ]
+    )
+    block.register(FunctionalFeature(lambda data: max(data) - min(data), name="range"))
+    block.extend([_SquareFeature(), _IdentityFeature(name="identity")])
+    data = [1, 2, 3]
+    result = block(data)
+    assert set(result) == {"sum", "range", "square", "identity"}
+    assert result["sum"] == 6
+    assert result["identity"] == data
+
+
+def test_functional_feature_preserves_metadata():
+    feature = FunctionalFeature(
+        lambda values: np.asarray(values).std(),
+        name="std",
+        metadata={"stat": "std"},
+    )
+    out = feature([1, 2, 3])
+    assert out.name == "std"
+    assert out.metadata == {"stat": "std"}
+
+
+def test_feature_block_features_property_is_immutable():
+    feature = _IdentityFeature(name="id")
+    block = FeatureBlock([feature])
+    features = block.features
+    assert features == (feature,)
+    with pytest.raises(AttributeError):
+        features.append(feature)  # type: ignore[attr-defined]

--- a/tests/test_hurst.py
+++ b/tests/test_hurst.py
@@ -1,8 +1,37 @@
 # SPDX-License-Identifier: MIT
+import pathlib
+import sys
+
 import numpy as np
-from core.indicators.hurst import hurst_exponent
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.indicators.hurst import HurstFeature, hurst_exponent
+
 
 def test_hurst_bounds():
     x = np.cumsum(np.random.randn(1000))
     H = hurst_exponent(x)
     assert 0.0 <= H <= 1.0
+
+
+def test_hurst_returns_half_for_short_series():
+    short_series = np.arange(5, dtype=float)
+    H = hurst_exponent(short_series, max_lag=10)
+    assert H == 0.5
+
+
+def test_hurst_feature_metadata():
+    x = np.cumsum(np.random.randn(1000))
+    feature = HurstFeature(min_lag=5, max_lag=30)
+    result = feature(x)
+    assert result.metadata == {"min_lag": 5, "max_lag": 30}
+
+
+def test_hurst_feature_custom_name():
+    x = np.cumsum(np.random.randn(512))
+    feature = HurstFeature(name="hurst_signal")
+    result = feature(x)
+    assert result.name == "hurst_signal"

--- a/tests/test_kuramoto.py
+++ b/tests/test_kuramoto.py
@@ -1,9 +1,131 @@
 # SPDX-License-Identifier: MIT
+import pathlib
+import sys
+
 import numpy as np
-from core.indicators.kuramoto import compute_phase, kuramoto_order
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.indicators.kuramoto import (
+    KuramotoOrderFeature,
+    MultiAssetKuramotoFeature,
+    compute_phase,
+    compute_phase_gpu,
+    kuramoto_order,
+    multi_asset_kuramoto,
+)
+from core.indicators import kuramoto as kuramoto_module
+
 
 def test_kuramoto_range():
-    x = np.sin(np.linspace(0, 10*np.pi, 1000))
+    x = np.sin(np.linspace(0, 10 * np.pi, 1000))
     ph = compute_phase(x)
     R = kuramoto_order(ph[-200:])
     assert 0.0 <= R <= 1.0
+
+
+def test_compute_phase_validates_dimension():
+    with pytest.raises(ValueError):
+        compute_phase(np.zeros((4, 4)))
+
+
+def test_compute_phase_gpu_falls_back_to_cpu():
+    x = np.sin(np.linspace(0, 2 * np.pi, 128))
+    cpu = compute_phase(x)
+    gpu = compute_phase_gpu(x)
+    assert gpu.shape == cpu.shape
+    assert np.allclose(gpu, cpu, atol=1e-6)
+
+
+def test_compute_phase_fft_branch_handles_odd_length():
+    x = np.sin(np.linspace(0, 2 * np.pi, 129))
+    phases = compute_phase(x)
+    assert phases.shape == (129,)
+
+
+def test_multi_asset_kuramoto_last_step_alignment():
+    series = [
+        np.sin(np.linspace(0, np.pi, 256)),
+        np.sin(np.linspace(0, np.pi, 256) + np.pi / 4),
+    ]
+    value = multi_asset_kuramoto(series)
+    assert 0.0 <= value <= 1.0
+
+
+def test_compute_phase_uses_hilbert_when_available(monkeypatch: pytest.MonkeyPatch):
+    calls: dict[str, int] = {"count": 0}
+
+    def fake_hilbert(x):
+        calls["count"] += 1
+        return x + 1j * np.ones_like(x)
+
+    monkeypatch.setattr(kuramoto_module, "hilbert", fake_hilbert)
+    phases = kuramoto_module.compute_phase(np.ones(16))
+    assert calls["count"] == 1
+    assert phases.shape == (16,)
+
+
+def test_kuramoto_order_handles_matrix_input():
+    phases = np.vstack(
+        [
+            np.random.uniform(-np.pi, np.pi, size=64),
+            np.random.uniform(-np.pi, np.pi, size=64),
+        ]
+    )
+    values = kuramoto_order(phases)
+    assert values.shape == (64,)
+    assert np.all((0.0 <= values) & (values <= 1.0))
+
+
+def test_compute_phase_gpu_with_fake_cupy(monkeypatch: pytest.MonkeyPatch):
+    class _FakeFFT:
+        @staticmethod
+        def rfft(x, n):
+            return np.fft.rfft(x, n)
+
+        @staticmethod
+        def irfft(x, n):
+            return np.fft.irfft(x, n)
+
+    class _FakeCP:
+        float32 = np.float32
+        fft = _FakeFFT()
+
+        @staticmethod
+        def asarray(x, dtype=None):
+            return np.asarray(x, dtype=dtype)
+
+        @staticmethod
+        def zeros_like(x):
+            return np.zeros_like(x)
+
+        @staticmethod
+        def angle(x):
+            return np.angle(x)
+
+        @staticmethod
+        def asnumpy(x):
+            return np.asarray(x)
+
+    monkeypatch.setattr(kuramoto_module, "cp", _FakeCP())
+    phases_even = compute_phase_gpu(np.sin(np.linspace(0, 2 * np.pi, 64)))
+    phases_odd = compute_phase_gpu(np.sin(np.linspace(0, 2 * np.pi, 65)))
+    assert phases_even.shape == (64,)
+    assert phases_odd.shape == (65,)
+
+
+def test_kuramoto_feature_block_single_series():
+    ph = np.random.uniform(-np.pi, np.pi, size=512)
+    feature = KuramotoOrderFeature()
+    result = feature(ph)
+    assert 0.0 <= result.value <= 1.0
+
+
+def test_multi_asset_kuramoto_feature_counts_assets():
+    series = [np.sin(np.linspace(0, np.pi, 100)) for _ in range(3)]
+    feature = MultiAssetKuramotoFeature()
+    result = feature(series)
+    assert result.metadata["assets"] == 3

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,8 +1,24 @@
 # SPDX-License-Identifier: MIT
+import pathlib
+import sys
+
 import numpy as np
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from core.indicators.kuramoto import kuramoto_order
+
 
 def test_R_bounds_property():
     ph = np.random.uniform(-np.pi, np.pi, size=512)
     R = kuramoto_order(ph)
     assert 0.0 <= R <= 1.0
+
+
+def test_kuramoto_order_invariant_to_phase_shift():
+    phases = np.random.uniform(-np.pi, np.pi, size=256)
+    base = kuramoto_order(phases)
+    shifted = kuramoto_order(phases + np.pi / 3)
+    assert np.isclose(base, shifted, atol=1e-6)

--- a/tests/test_ricci.py
+++ b/tests/test_ricci.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.indicators import ricci as ricci_module
+from core.indicators.ricci import (
+    MeanRicciFeature,
+    build_price_graph,
+    local_distribution,
+    mean_ricci,
+    ricci_curvature_edge,
+)
+
+
+def test_mean_ricci_feature_returns_metadata():
+    prices = np.cumsum(np.random.randn(256)) + 100
+    feature = MeanRicciFeature(delta=0.01)
+    result = feature(prices)
+    assert "nodes" in result.metadata
+    assert result.metadata["delta"] == 0.01
+
+
+def test_build_price_graph_connects_consecutive_levels():
+    prices = np.array([100, 101, 102, 101.5])
+    graph = build_price_graph(prices, delta=0.01)
+    assert graph.number_of_nodes() >= 3
+    assert graph.number_of_edges() >= 2
+
+
+def test_local_distribution_returns_probability():
+    prices = np.array([100, 100.5, 101.0, 101.5])
+    graph = build_price_graph(prices, delta=0.01)
+    nodes_iter = graph.nodes() if hasattr(graph, "nodes") else graph._adj.keys()  # type: ignore[attr-defined]
+    node = next(iter(nodes_iter))
+    distribution = local_distribution(graph, node)
+    assert np.isclose(distribution.sum(), 1.0)
+
+
+def test_local_distribution_returns_unity_for_isolated_node():
+    prices = np.array([100.0])
+    graph = build_price_graph(prices, delta=0.01)
+    nodes_iter = graph.nodes() if hasattr(graph, "nodes") else graph._adj.keys()  # type: ignore[attr-defined]
+    node = next(iter(nodes_iter))
+    distribution = local_distribution(graph, node)
+    assert np.array_equal(distribution, np.array([1.0]))
+
+
+def test_ricci_curvature_falls_back_without_wasserstein(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ricci_module, "W1", None)
+    prices = np.array([100, 101, 102, 103])
+    graph = build_price_graph(prices, delta=0.01)
+    edges = list(graph.edges())
+    assert edges
+    curvature = ricci_curvature_edge(graph, *edges[0])
+    assert -1.0 <= curvature <= 1.0
+
+
+def test_ricci_curvature_zero_when_no_edge():
+    prices = np.array([100, 101, 102])
+    graph = build_price_graph(prices, delta=0.01)
+    graph.add_node(999)
+    assert ricci_curvature_edge(graph, list(graph.edges())[0][0], 999) == 0.0
+
+
+def test_mean_ricci_graph_helpers():
+    prices = np.array([100, 101, 102, 101.5])
+    graph = build_price_graph(prices)
+    value = mean_ricci(graph)
+    assert isinstance(value, float)
+
+
+def test_mean_ricci_returns_zero_for_graph_without_edges():
+    graph = build_price_graph(np.array([100.0]))
+    assert mean_ricci(graph) == 0.0


### PR DESCRIPTION
## Summary
- add a CI workflow that runs pytest with coverage on every push to main and pull request
- expand the indicator test suite, including a new base-feature contract suite and richer entropy, hurst, kuramoto, and ricci coverage to hit 100% for core.indicators
- retune pytest configuration and dev dependencies to load repo tests correctly, silence asyncio warnings, and expose pytest-cov tooling

## Testing
- pytest
- pytest --cov=core/indicators --cov-report=term-missing --cov-report=xml

------
https://chatgpt.com/codex/tasks/task_e_68e2ecdd295c8329839d9ad360517cef