### PR TITLE
Add Kuramoto-Ricci composite indicator and supporting tests

### DIFF
--- a/core/indicators/__init__.py
+++ b/core/indicators/__init__.py
@@ -22,9 +22,16 @@ from .multiscale_kuramoto import (
 from .ricci import MeanRicciFeature, build_price_graph, local_distribution, mean_ricci, ricci_curvature_edge
 from .temporal_ricci import (
     GraphSnapshot,
+    OllivierRicciCurvature,
     PriceLevelGraphBuilder,
     TemporalRicciAnalyzer,
     TemporalRicciResult,
+)
+from .kuramoto_ricci_composite import (
+    CompositeSignal,
+    KuramotoRicciComposite,
+    MarketPhase,
+    TradePulseCompositeEngine,
 )
 
 __all__ = [
@@ -55,14 +62,14 @@ __all__ = [
     "ricci_curvature_edge",
     "mean_ricci",
     "MeanRicciFeature",
-    "MultiScaleKuramoto",
-    "MultiScaleKuramotoFeature",
-    "MultiScaleResult",
-    "TimeFrame",
-    "WaveletWindowSelector",
     "GraphSnapshot",
+    "OllivierRicciCurvature",
     "PriceLevelGraphBuilder",
     "TemporalRicciAnalyzer",
     "TemporalRicciResult",
+    "CompositeSignal",
+    "KuramotoRicciComposite",
+    "MarketPhase",
+    "TradePulseCompositeEngine",
 ]
 

--- a/core/indicators/kuramoto_ricci_composite.py
+++ b/core/indicators/kuramoto_ricci_composite.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: MIT
+"""Composite indicator combining Kuramoto synchronisation and Ricci curvature."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from enum import Enum, auto
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+from .multiscale_kuramoto import MultiScaleKuramoto, MultiScaleResult
+from .temporal_ricci import TemporalRicciAnalyzer, TemporalRicciResult
+from .ricci import build_price_graph, mean_ricci
+
+
+class MarketPhase(Enum):
+    """High level market regimes detected by the composite engine."""
+
+    CHAOTIC = auto()
+    TRANSITION = auto()
+    STRONG_EMERGENT = auto()
+    POST_EMERGENT = auto()
+    STABLE = auto()
+
+
+@dataclass(slots=True)
+class CompositeSignal:
+    """Signal emitted by :class:`TradePulseCompositeEngine`."""
+
+    phase: MarketPhase
+    confidence: float
+    entry_signal: float
+    exit_signal: float
+    risk_multiplier: float
+    kuramoto_R: float
+    temporal_ricci: float
+    transition_score: float
+    static_ricci: float
+    timestamp: Optional[pd.Timestamp] = None
+
+    def as_dict(self) -> dict[str, float | str | None]:
+        payload = asdict(self)
+        payload["phase"] = self.phase.name
+        if self.timestamp is not None:
+            payload["timestamp"] = pd.Timestamp(self.timestamp)
+        return payload
+
+
+class KuramotoRicciComposite:
+    """Logic that maps raw indicators into market phases and trading signals."""
+
+    def __init__(
+        self,
+        *,
+        R_strong_emergent: float = 0.8,
+        R_emergent: float = 0.65,
+        R_low: float = 0.35,
+        ricci_negative_threshold: float = -0.25,
+        transition_threshold: float = 0.65,
+        post_transition_threshold: float = 0.45,
+        min_confidence: float = 0.35,
+    ) -> None:
+        self.R_strong_emergent = float(R_strong_emergent)
+        self.R_emergent = float(R_emergent)
+        self.R_low = float(R_low)
+        self.ricci_negative_threshold = float(ricci_negative_threshold)
+        self.transition_threshold = float(transition_threshold)
+        self.post_transition_threshold = float(post_transition_threshold)
+        self.min_confidence = float(min_confidence)
+
+    def _determine_phase(
+        self,
+        *,
+        R: float,
+        temporal_ricci: float,
+        transition_score: float,
+        static_ricci: float,
+    ) -> MarketPhase:
+        transition_score = float(np.clip(transition_score, 0.0, 1.0))
+        R = float(np.clip(R, 0.0, 1.0))
+
+        if transition_score >= self.transition_threshold:
+            return MarketPhase.TRANSITION
+
+        min_ricci = min(float(temporal_ricci), float(static_ricci))
+        if R >= self.R_strong_emergent and min_ricci <= self.ricci_negative_threshold:
+            return MarketPhase.STRONG_EMERGENT
+
+        if transition_score >= self.post_transition_threshold:
+            return MarketPhase.POST_EMERGENT
+
+        if R >= self.R_emergent:
+            return MarketPhase.STABLE
+
+        if R <= self.R_low:
+            return MarketPhase.CHAOTIC
+
+        return MarketPhase.STABLE
+
+    def _compute_confidence(
+        self,
+        *,
+        phase: MarketPhase,
+        coherence: float,
+        transition_score: float,
+        R: float,
+    ) -> float:
+        coherence = float(np.clip(coherence, 0.0, 1.0))
+        transition_score = float(np.clip(transition_score, 0.0, 1.0))
+        R = float(np.clip(R, 0.0, 1.0))
+
+        base = 0.5 * coherence + 0.3 * R + 0.2 * (1.0 - transition_score)
+        if phase is MarketPhase.TRANSITION:
+            base *= 0.75
+        elif phase is MarketPhase.STRONG_EMERGENT:
+            base = min(1.0, base + 0.1)
+        return float(np.clip(base, 0.0, 1.0))
+
+    def _generate_entry_signal(
+        self,
+        *,
+        phase: MarketPhase,
+        R: float,
+        temporal_ricci: float,
+        transition_score: float,
+        confidence: float,
+    ) -> float:
+        confidence = float(np.clip(confidence, 0.0, 1.0))
+        if confidence < self.min_confidence:
+            return 0.0
+
+        R = float(np.clip(R, 0.0, 1.0))
+        transition_score = float(np.clip(transition_score, 0.0, 1.0))
+
+        if phase is MarketPhase.STRONG_EMERGENT:
+            curvature_boost = float(np.clip(-temporal_ricci, 0.0, 1.0))
+            signal = confidence * (0.4 + 0.4 * R + 0.4 * curvature_boost)
+        elif phase is MarketPhase.TRANSITION:
+            signal = confidence * (0.5 - transition_score)
+        elif phase is MarketPhase.CHAOTIC:
+            signal = -confidence * (0.3 + 0.4 * (1.0 - R))
+        else:
+            signal = confidence * 0.5 * R
+
+        return float(np.clip(signal, -1.0, 1.0))
+
+    def _generate_exit_signal(
+        self,
+        *,
+        phase: MarketPhase,
+        transition_score: float,
+        R: float,
+    ) -> float:
+        transition_score = float(np.clip(transition_score, 0.0, 1.0))
+        R = float(np.clip(R, 0.0, 1.0))
+
+        base = 0.6 * transition_score + 0.4 * (1.0 - R)
+        if phase is MarketPhase.POST_EMERGENT:
+            base = min(1.0, base + 0.2)
+        elif phase is MarketPhase.STRONG_EMERGENT:
+            base *= 0.5
+        return float(np.clip(base, 0.0, 1.0))
+
+    def _compute_risk_multiplier(
+        self,
+        *,
+        phase: MarketPhase,
+        confidence: float,
+        coherence: float,
+    ) -> float:
+        confidence = float(np.clip(confidence, 0.0, 1.0))
+        coherence = float(np.clip(coherence, 0.0, 1.0))
+
+        base = 1.0 + 0.6 * (confidence - 0.5) + 0.4 * (coherence - 0.5)
+        if phase is MarketPhase.STRONG_EMERGENT:
+            base += 0.2 * confidence
+        elif phase is MarketPhase.TRANSITION:
+            base -= 0.3 * (1.0 - confidence)
+        elif phase is MarketPhase.CHAOTIC:
+            base -= 0.2
+        return float(np.clip(base, 0.1, 2.0))
+
+
+class TradePulseCompositeEngine:
+    """High level orchestration of the composite indicator pipeline."""
+
+    def __init__(
+        self,
+        *,
+        kuramoto: Optional[MultiScaleKuramoto] = None,
+        temporal_ricci: Optional[TemporalRicciAnalyzer] = None,
+        composite: Optional[KuramotoRicciComposite] = None,
+        price_col: str = "close",
+        volume_col: Optional[str] = "volume",
+    ) -> None:
+        self.kuramoto = kuramoto or MultiScaleKuramoto()
+        self.temporal_ricci = temporal_ricci or TemporalRicciAnalyzer()
+        self.composite = composite or KuramotoRicciComposite()
+        self.price_col = price_col
+        self.volume_col = volume_col
+        self.signal_history: List[CompositeSignal] = []
+
+    def _static_ricci(self, prices: np.ndarray) -> float:
+        graph = build_price_graph(prices)
+        return float(mean_ricci(graph))
+
+    def analyze_market(self, df: pd.DataFrame) -> CompositeSignal:
+        if self.price_col not in df.columns:
+            raise KeyError(f"Column '{self.price_col}' not found in dataframe")
+
+        prices = df[self.price_col].astype(float)
+
+        kuramoto_result: MultiScaleResult = self.kuramoto.analyze(df, price_col=self.price_col)
+        temporal_result: TemporalRicciResult = self.temporal_ricci.analyze(
+            df,
+            price_col=self.price_col,
+            volume_col=self.volume_col,
+        )
+        static_ricci = self._static_ricci(prices.to_numpy())
+
+        phase = self.composite._determine_phase(
+            R=kuramoto_result.consensus_R,
+            temporal_ricci=temporal_result.temporal_curvature,
+            transition_score=temporal_result.topological_transition_score,
+            static_ricci=static_ricci,
+        )
+
+        confidence = self.composite._compute_confidence(
+            phase=phase,
+            coherence=kuramoto_result.cross_scale_coherence,
+            transition_score=temporal_result.topological_transition_score,
+            R=kuramoto_result.consensus_R,
+        )
+
+        entry_signal = self.composite._generate_entry_signal(
+            phase=phase,
+            R=kuramoto_result.consensus_R,
+            temporal_ricci=temporal_result.temporal_curvature,
+            transition_score=temporal_result.topological_transition_score,
+            confidence=confidence,
+        )
+
+        exit_signal = self.composite._generate_exit_signal(
+            phase=phase,
+            transition_score=temporal_result.topological_transition_score,
+            R=kuramoto_result.consensus_R,
+        )
+
+        risk_multiplier = self.composite._compute_risk_multiplier(
+            phase=phase,
+            confidence=confidence,
+            coherence=kuramoto_result.cross_scale_coherence,
+        )
+
+        timestamp = prices.index[-1] if isinstance(prices.index, pd.DatetimeIndex) else None
+
+        signal = CompositeSignal(
+            phase=phase,
+            confidence=confidence,
+            entry_signal=entry_signal,
+            exit_signal=exit_signal,
+            risk_multiplier=risk_multiplier,
+            kuramoto_R=kuramoto_result.consensus_R,
+            temporal_ricci=temporal_result.temporal_curvature,
+            transition_score=temporal_result.topological_transition_score,
+            static_ricci=static_ricci,
+            timestamp=timestamp,
+        )
+
+        self.signal_history.append(signal)
+        return signal
+
+    def get_signal_dataframe(self) -> pd.DataFrame:
+        if not self.signal_history:
+            return pd.DataFrame(columns=[
+                "phase",
+                "confidence",
+                "entry_signal",
+                "exit_signal",
+                "risk_multiplier",
+                "kuramoto_R",
+                "temporal_ricci",
+                "transition_score",
+                "static_ricci",
+                "timestamp",
+            ])
+        records = [signal.as_dict() for signal in self.signal_history]
+        df = pd.DataFrame.from_records(records)
+        if "timestamp" in df.columns and df["timestamp"].notna().any():
+            df["timestamp"] = pd.to_datetime(df["timestamp"])
+        return df
+
+
+__all__ = [
+    "CompositeSignal",
+    "KuramotoRicciComposite",
+    "MarketPhase",
+    "TradePulseCompositeEngine",
+]

--- a/core/indicators/multiscale_kuramoto.py
+++ b/core/indicators/multiscale_kuramoto.py
@@ -169,6 +169,18 @@ class MultiScaleKuramoto:
         )
         return result
 
+    def _kuramoto_order_parameter(self, phases: np.ndarray) -> tuple[float, float]:
+        """Return the Kuramoto order parameter ``R`` and mean phase ``ψ``."""
+
+        values = np.asarray(phases, dtype=float)
+        if values.size == 0:
+            return 0.0, 0.0
+
+        complex_order = np.mean(np.exp(1j * values))
+        R = float(np.clip(np.abs(complex_order), 0.0, 1.0))
+        psi = float(np.angle(complex_order))
+        return R, psi
+
     def _select_window(self, prices: np.ndarray) -> int:
         if not self.use_adaptive_window:
             return self.base_window
@@ -189,9 +201,9 @@ class MultiScaleKuramoto:
         psi_values: List[float] = []
         for end in range(window, phases.size + 1):
             window_phases = phases[end - window : end]
-            complex_r = np.mean(np.exp(1j * window_phases))
-            r_values.append(float(np.abs(complex_r)))
-            psi_values.append(float(np.angle(complex_r)))
+            R, psi = self._kuramoto_order_parameter(window_phases)
+            r_values.append(R)
+            psi_values.append(psi)
 
         R_current = r_values[-1] if r_values else 0.0
         psi_current = psi_values[-1] if psi_values else 0.0

--- a/core/indicators/temporal_ricci.py
+++ b/core/indicators/temporal_ricci.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -57,6 +57,30 @@ class TemporalRicciResult:
     graph_snapshots: List[GraphSnapshot]
     structural_stability: float
     edge_persistence: float
+
+
+class OllivierRicciCurvature:
+    """Light-weight Ollivier--Ricci curvature calculator for graphs."""
+
+    def __init__(self, alpha: float = 0.5) -> None:
+        self.alpha = float(alpha)
+
+    def compute_edge_curvature(self, graph: "nx.Graph", edge: Tuple[int, int]) -> float:
+        if len(edge) != 2:
+            raise ValueError("edge must contain exactly two node identifiers")
+        u, v = (int(edge[0]), int(edge[1]))
+        if graph.has_edge(u, v):
+            return float(ricci_curvature_edge(graph, u, v))
+        if graph.has_edge(v, u):
+            return float(ricci_curvature_edge(graph, v, u))
+        return 0.0
+
+    def compute_all_curvatures(self, graph: "nx.Graph") -> Mapping[Tuple[int, int], float]:
+        curvatures: Dict[Tuple[int, int], float] = {}
+        for u, v in graph.edges():
+            edge = (min(int(u), int(v)), max(int(u), int(v)))
+            curvatures[edge] = self.compute_edge_curvature(graph, edge)
+        return curvatures
 
 
 class PriceLevelGraphBuilder:
@@ -364,6 +388,7 @@ def _safe_entropy(p: np.ndarray, q: np.ndarray) -> float:
 
 
 __all__ = [
+    "OllivierRicciCurvature",
     "GraphSnapshot",
     "TemporalRicciResult",
     "PriceLevelGraphBuilder",

--- a/tests/unit/test_kuramoto_ricci_composite.py
+++ b/tests/unit/test_kuramoto_ricci_composite.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+try:
+    from hypothesis import given, settings, strategies as st
+    from hypothesis.extra.numpy import arrays
+except Exception:  # pragma: no cover - optional dependency
+    HYPOTHESIS_AVAILABLE = False
+else:  # pragma: no branch
+    HYPOTHESIS_AVAILABLE = True
+
+from core.indicators import (
+    KuramotoRicciComposite,
+    MarketPhase,
+    MultiScaleKuramoto,
+    TemporalRicciAnalyzer,
+    TimeFrame,
+    TradePulseCompositeEngine,
+    WaveletWindowSelector,
+)
+from core.indicators.temporal_ricci import OllivierRicciCurvature
+
+
+class TestMultiScaleKuramoto:
+    def test_kuramoto_order_parameter_bounds(self) -> None:
+        analyzer = MultiScaleKuramoto(use_adaptive_window=False)
+        phases = np.random.uniform(-np.pi, np.pi, 128)
+        R, psi = analyzer._kuramoto_order_parameter(phases)
+        assert 0.0 <= R <= 1.0
+        assert -np.pi <= psi <= np.pi
+
+    def test_perfect_synchronisation(self) -> None:
+        analyzer = MultiScaleKuramoto(use_adaptive_window=False)
+        phases = np.ones(64) * (np.pi / 4.0)
+        R, _ = analyzer._kuramoto_order_parameter(phases)
+        assert R > 0.99
+
+    def test_random_phases_low_R(self) -> None:
+        analyzer = MultiScaleKuramoto(use_adaptive_window=False)
+        rng = np.random.default_rng(42)
+        phases = rng.uniform(-np.pi, np.pi, 2048)
+        R, _ = analyzer._kuramoto_order_parameter(phases)
+        assert R < 0.2
+
+    def test_adaptive_window_selection(self) -> None:
+        selector = WaveletWindowSelector(min_window=50, max_window=200)
+        t = np.arange(512)
+        prices = 100 + 5 * np.sin(2 * np.pi * t / 64)
+        window = selector.select_window(prices)
+        assert 50 <= window <= 200
+
+    def test_multiscale_consensus(self) -> None:
+        dates = pd.date_range("2024-01-01", periods=512, freq="1min")
+        t = np.arange(len(dates))
+        prices = 100 + np.sin(2 * np.pi * t / 50) + 0.3 * np.sin(2 * np.pi * t / 120)
+        df = pd.DataFrame({"close": prices}, index=dates)
+
+        analyzer = MultiScaleKuramoto(use_adaptive_window=False, base_window=64)
+        result = analyzer.analyze(df)
+        assert 0.0 <= result.consensus_R <= 1.0
+        assert 0.0 <= result.cross_scale_coherence <= 1.0
+        assert result.dominant_scale in TimeFrame
+
+    if HYPOTHESIS_AVAILABLE:
+
+        @settings(max_examples=5, deadline=None)
+        @given(
+            prices=arrays(
+                dtype=np.float64,
+                shape=st.integers(min_value=200, max_value=600),
+                elements=st.floats(min_value=50.0, max_value=150.0, allow_nan=False),
+            )
+        )
+        def test_kuramoto_robustness(self, prices: np.ndarray) -> None:
+            dates = pd.date_range("2024-01-01", periods=len(prices), freq="1min")
+            df = pd.DataFrame({"close": prices}, index=dates)
+            analyzer = MultiScaleKuramoto(use_adaptive_window=False, base_window=64)
+            result = analyzer.analyze(df)
+            assert 0.0 <= result.consensus_R <= 1.0
+            assert not np.isnan(result.consensus_R)
+    else:  # pragma: no cover - executed when Hypothesis missing
+
+        def test_kuramoto_robustness(self) -> None:  # type: ignore[override]
+            pytest.skip("hypothesis not installed")
+
+
+class TestTemporalRicci:
+    def test_ollivier_ricci_symmetry(self) -> None:
+        nx = pytest.importorskip("networkx")
+
+        G = nx.complete_graph(5)
+        calculator = OllivierRicciCurvature(alpha=0.5)
+        for edge in G.edges():
+            x, y = edge
+            kappa_xy = calculator.compute_edge_curvature(G, (x, y))
+            kappa_yx = calculator.compute_edge_curvature(G, (y, x))
+            assert abs(kappa_xy - kappa_yx) < 1e-10
+
+    def test_complete_graph_positive_curvature(self) -> None:
+        nx = pytest.importorskip("networkx")
+
+        G = nx.complete_graph(8)
+        calculator = OllivierRicciCurvature()
+        curvatures = calculator.compute_all_curvatures(G)
+        assert np.mean(list(curvatures.values())) > 0
+
+    def test_temporal_ricci_detects_regime_change(self) -> None:
+        dates = pd.date_range("2024-01-01", periods=800, freq="1min")
+        rng = np.random.default_rng(123)
+        stable = 100 + np.cumsum(rng.normal(0, 0.05, 400))
+        volatile = stable[-1] + np.cumsum(rng.normal(0, 0.8, 400))
+        prices = np.concatenate([stable, volatile])
+        volumes = rng.lognormal(mean=7, sigma=0.5, size=len(prices))
+        df = pd.DataFrame({"close": prices, "volume": volumes}, index=dates)
+
+        analyzer = TemporalRicciAnalyzer(window_size=80, n_snapshots=8)
+        result = analyzer.analyze(df)
+        assert result.topological_transition_score > 0.3
+
+    def test_stable_market_high_stability(self) -> None:
+        dates = pd.date_range("2024-01-01", periods=600, freq="1min")
+        rng = np.random.default_rng(321)
+        prices = 100 + 0.01 * np.arange(len(dates)) + rng.normal(0, 0.05, len(dates))
+        volumes = np.full(len(dates), 1000.0)
+        df = pd.DataFrame({"close": prices, "volume": volumes}, index=dates)
+
+        analyzer = TemporalRicciAnalyzer(window_size=80, n_snapshots=6)
+        result = analyzer.analyze(df)
+        assert result.structural_stability > 0.35
+
+
+class TestCompositeIndicator:
+    def test_phase_detection_strong_emergent(self) -> None:
+        composite = KuramotoRicciComposite(R_strong_emergent=0.8, ricci_negative_threshold=-0.3)
+        phase = composite._determine_phase(
+            R=0.85,
+            temporal_ricci=-0.25,
+            transition_score=0.3,
+            static_ricci=-0.4,
+        )
+        assert phase is MarketPhase.STRONG_EMERGENT
+
+    def test_phase_detection_transition(self) -> None:
+        composite = KuramotoRicciComposite()
+        phase = composite._determine_phase(
+            R=0.6,
+            temporal_ricci=-0.1,
+            transition_score=0.8,
+            static_ricci=-0.2,
+        )
+        assert phase is MarketPhase.TRANSITION
+
+    def test_confidence_range(self) -> None:
+        composite = KuramotoRicciComposite()
+        confidence = composite._compute_confidence(
+            phase=MarketPhase.STRONG_EMERGENT,
+            coherence=0.8,
+            transition_score=0.2,
+            R=0.9,
+        )
+        assert 0.0 <= confidence <= 1.0
+
+    def test_entry_signal_range(self) -> None:
+        composite = KuramotoRicciComposite()
+        signal = composite._generate_entry_signal(
+            phase=MarketPhase.STRONG_EMERGENT,
+            R=0.9,
+            temporal_ricci=-0.4,
+            transition_score=0.2,
+            confidence=0.8,
+        )
+        assert -1.0 <= signal <= 1.0
+
+    def test_exit_signal_range(self) -> None:
+        composite = KuramotoRicciComposite()
+        signal = composite._generate_exit_signal(
+            phase=MarketPhase.POST_EMERGENT,
+            transition_score=0.6,
+            R=0.5,
+        )
+        assert 0.0 <= signal <= 1.0
+
+    def test_risk_multiplier_range(self) -> None:
+        composite = KuramotoRicciComposite()
+        multiplier = composite._compute_risk_multiplier(
+            phase=MarketPhase.STRONG_EMERGENT,
+            confidence=0.9,
+            coherence=0.8,
+        )
+        assert 0.1 <= multiplier <= 2.0
+
+    def test_low_confidence_zero_entry(self) -> None:
+        composite = KuramotoRicciComposite(min_confidence=0.5)
+        signal = composite._generate_entry_signal(
+            phase=MarketPhase.STRONG_EMERGENT,
+            R=0.9,
+            temporal_ricci=-0.4,
+            transition_score=0.2,
+            confidence=0.3,
+        )
+        assert abs(signal) < 0.1
+
+
+class TestCompositeEngine:
+    def test_full_pipeline(self) -> None:
+        dates = pd.date_range("2024-01-01", periods=600, freq="1min")
+        rng = np.random.default_rng(987)
+        t = np.arange(len(dates))
+        prices = 100 + 3 * np.sin(2 * np.pi * t / 150) + rng.normal(0, 0.4, len(dates))
+        volumes = rng.lognormal(mean=7, sigma=0.6, size=len(dates))
+        df = pd.DataFrame({"close": prices, "volume": volumes}, index=dates)
+
+        engine = TradePulseCompositeEngine()
+        signal = engine.analyze_market(df)
+
+        assert signal.phase in MarketPhase
+        assert 0.0 <= signal.confidence <= 1.0
+        assert -1.0 <= signal.entry_signal <= 1.0
+        assert 0.0 <= signal.exit_signal <= 1.0
+        assert 0.1 <= signal.risk_multiplier <= 2.0
+        assert not np.isnan(signal.kuramoto_R)
+        assert not np.isnan(signal.temporal_ricci)
+
+    def test_signal_history_tracking(self) -> None:
+        dates = pd.date_range("2024-01-01", periods=300, freq="1min")
+        rng = np.random.default_rng(654)
+        prices = 100 + rng.normal(0, 0.5, len(dates))
+        volumes = np.full(len(dates), 1000.0)
+        df = pd.DataFrame({"close": prices, "volume": volumes}, index=dates)
+
+        engine = TradePulseCompositeEngine()
+        engine.analyze_market(df)
+        engine.analyze_market(df)
+
+        assert len(engine.signal_history) == 2
+        df_signals = engine.get_signal_dataframe()
+        assert len(df_signals) == 2
+        assert set(["phase", "entry_signal"]).issubset(df_signals.columns)
+
+
+if HYPOTHESIS_AVAILABLE:
+
+    @st.composite
+    def _synthetic_series(draw: st.DrawFn) -> np.ndarray:
+        n_points = draw(st.integers(min_value=200, max_value=600))
+        volatility = draw(st.floats(min_value=0.01, max_value=2.0))
+        rng = np.random.default_rng(draw(st.integers(min_value=0, max_value=10_000)))
+        return 100 + np.cumsum(rng.normal(0, volatility, n_points))
+
+
+    class TestPropertyBased:
+        @settings(max_examples=5, deadline=None)
+        @given(series=_synthetic_series())
+        def test_engine_handles_various_volatilities(self, series: np.ndarray) -> None:
+            dates = pd.date_range("2024-01-01", periods=len(series), freq="1min")
+            df = pd.DataFrame({"close": series, "volume": np.full(len(series), 1000.0)}, index=dates)
+
+            engine = TradePulseCompositeEngine()
+            signal = engine.analyze_market(df)
+            assert signal.phase in MarketPhase
+            assert not np.isnan(signal.confidence)
+else:  # pragma: no cover - Hypothesis not available
+
+    class TestPropertyBased:  # type: ignore[no-redef]
+        def test_engine_handles_various_volatilities(self) -> None:
+            pytest.skip("hypothesis not installed")


### PR DESCRIPTION
## Summary
- expose a reusable `_kuramoto_order_parameter` helper inside `MultiScaleKuramoto`
- add an `OllivierRicciCurvature` utility and a full Kuramoto-Ricci composite engine
- cover the combined functionality with targeted unit and property tests

## Testing
- pytest tests/unit/test_kuramoto_ricci_composite.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4048875a0832981450c3935ea6410