### PR TITLE
Revert indicator stack to stable baseline

### DIFF
--- a/configs/kuramoto_ricci_composite.yaml
+++ b/configs/kuramoto_ricci_composite.yaml
@@ -3,6 +3,8 @@ kuramoto:
   timeframes: [60, 300, 900, 3600]
   adaptive_window:
     enabled: true
+    min_window: 64
+    max_window: 512
     base_window: 200
 
 ricci:

--- a/core/indicators/kuramoto_ricci_composite.py
+++ b/core/indicators/kuramoto_ricci_composite.py
@@ -1,12 +1,17 @@
+"""Composite indicator blending Kuramoto and Ricci analytics."""
 
-import numpy as np
-import pandas as pd
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional
 
+import numpy as np
+import pandas as pd
+
 from .multiscale_kuramoto import MultiScaleKuramoto, MultiScaleResult
 from .temporal_ricci import TemporalRicciAnalyzer, TemporalRicciResult
+
 
 class MarketPhase(Enum):
     CHAOTIC = "chaotic"
@@ -15,7 +20,8 @@ class MarketPhase(Enum):
     TRANSITION = "transition"
     POST_EMERGENT = "post_emergent"
 
-@dataclass
+
+@dataclass(slots=True)
 class CompositeSignal:
     phase: MarketPhase
     confidence: float
@@ -30,117 +36,200 @@ class CompositeSignal:
     risk_multiplier: float
     dominant_timeframe_sec: Optional[int]
     timestamp: pd.Timestamp
+    skipped_timeframes: list[str] = field(default_factory=list)
+
 
 class KuramotoRicciComposite:
-    def __init__(self, R_strong_emergent: float = 0.8, R_proto_emergent: float = 0.4,
-                 coherence_threshold: float = 0.6, ricci_negative_threshold: float = -0.3,
-                 temporal_ricci_threshold: float = -0.2, transition_threshold: float = 0.7,
-                 min_confidence: float = 0.5):
-        self.Rs = R_strong_emergent
-        self.Rp = R_proto_emergent
-        self.coh_min = coherence_threshold
-        self.kneg = ricci_negative_threshold
-        self.kt_thr = temporal_ricci_threshold
-        self.trans_thr = transition_threshold
-        self.min_conf = min_confidence
+    """Heuristic fusion of Kuramoto synchrony and Ricci curvature signals."""
 
-    def _phase(self, R: float, kt: float, trans: float, k_static: float) -> MarketPhase:
-        if (R > self.Rs and k_static < self.kneg and kt < self.kt_thr and trans < 0.5):
+    def __init__(
+        self,
+        R_strong_emergent: float = 0.8,
+        R_proto_emergent: float = 0.4,
+        coherence_threshold: float = 0.6,
+        ricci_negative_threshold: float = -0.3,
+        temporal_ricci_threshold: float = -0.2,
+        transition_threshold: float = 0.7,
+        min_confidence: float = 0.5,
+    ) -> None:
+        self.Rs = float(R_strong_emergent)
+        self.Rp = float(R_proto_emergent)
+        self.coh_min = float(coherence_threshold)
+        self.kneg = float(ricci_negative_threshold)
+        self.kt_thr = float(temporal_ricci_threshold)
+        self.trans_thr = float(transition_threshold)
+        self.min_conf = float(min_confidence)
+
+    # ------------------------------------------------------------------
+    # Internal decision helpers
+    # ------------------------------------------------------------------
+    def _phase(self, R: float, kt: float, transition: float, static_ricci: float) -> MarketPhase:
+        if R > self.Rs and static_ricci < self.kneg and kt < self.kt_thr and transition < 0.5:
             return MarketPhase.STRONG_EMERGENT
-        if trans > self.trans_thr:
+        if transition > self.trans_thr:
             return MarketPhase.TRANSITION
-        if (self.Rp < R <= self.Rs and trans < 0.5 and k_static < 0):
+        if self.Rp < R <= self.Rs and transition < 0.5 and static_ricci < 0:
             return MarketPhase.PROTO_EMERGENT
-        if (R > self.Rp and (k_static > 0 or kt > 0)):
+        if R > self.Rp and (static_ricci > 0 or kt > 0):
             return MarketPhase.POST_EMERGENT
         return MarketPhase.CHAOTIC
 
-    def _confidence(self, phase: MarketPhase, coherence: float, trans: float, R: float) -> float:
-        conf = coherence
-        if phase == MarketPhase.STRONG_EMERGENT:
-            conf *= (1.0 + R)
-        elif phase == MarketPhase.CHAOTIC:
-            conf *= 0.5
-        elif phase == MarketPhase.TRANSITION:
-            conf *= (0.5 + 0.5 * trans)
-        # penalize near thresholds
-        dist = min(abs(R - self.Rs), abs(R - self.Rp))
-        if dist < 0.1: conf *= 0.8
-        return float(np.clip(conf, 0.0, 1.0))
+    def _confidence(self, phase: MarketPhase, coherence: float, transition: float, R: float) -> float:
+        confidence = float(coherence)
+        if phase is MarketPhase.STRONG_EMERGENT:
+            confidence *= 1.0 + R
+        elif phase is MarketPhase.CHAOTIC:
+            confidence *= 0.5
+        elif phase is MarketPhase.TRANSITION:
+            confidence *= 0.5 + 0.5 * transition
+        if coherence < self.coh_min:
+            confidence *= max(0.0, coherence / max(self.coh_min, 1e-9))
+        distance = min(abs(R - self.Rs), abs(R - self.Rp))
+        if distance < 0.1:
+            confidence *= 0.8
+        return float(np.clip(confidence, 0.0, 1.0))
 
-    def _entry(self, phase: MarketPhase, R: float, kt: float, conf: float) -> float:
-        if conf < self.min_conf: return 0.0
-        s = 0.0
-        if phase == MarketPhase.STRONG_EMERGENT:
-            s = np.clip(-kt, 0.0, 1.0)  # more negative -> stronger long
-        elif phase == MarketPhase.PROTO_EMERGENT:
-            s = 0.5 * R
-        elif phase == MarketPhase.POST_EMERGENT:
-            s = -0.3
-        else:
-            s = 0.0
-        return float(np.clip(s * conf, -1.0, 1.0))
+    def _entry(self, phase: MarketPhase, R: float, kt: float, confidence: float) -> float:
+        if confidence < self.min_conf:
+            return 0.0
+        signal = 0.0
+        if phase is MarketPhase.STRONG_EMERGENT:
+            signal = np.clip(-kt, 0.0, 1.0)
+        elif phase is MarketPhase.PROTO_EMERGENT:
+            signal = 0.5 * R
+        elif phase is MarketPhase.POST_EMERGENT:
+            signal = -0.3
+        return float(np.clip(signal * confidence, -1.0, 1.0))
 
-    def _exit(self, phase: MarketPhase, trans: float, R: float) -> float:
-        if phase == MarketPhase.POST_EMERGENT: return 0.7
-        if phase == MarketPhase.TRANSITION: return float(np.clip(trans, 0.0, 1.0))
-        if phase == MarketPhase.CHAOTIC: return 0.5
-        if phase == MarketPhase.STRONG_EMERGENT: return 0.1
+    def _exit(self, phase: MarketPhase, transition: float, R: float) -> float:
+        if phase is MarketPhase.POST_EMERGENT:
+            return 0.7
+        if phase is MarketPhase.TRANSITION:
+            return float(np.clip(transition, 0.0, 1.0))
+        if phase is MarketPhase.CHAOTIC:
+            return 0.5
+        if phase is MarketPhase.STRONG_EMERGENT:
+            return 0.1
         return 0.3
 
-    def _risk(self, phase: MarketPhase, conf: float, coh: float) -> float:
+    def _risk(self, phase: MarketPhase, confidence: float, coherence: float) -> float:
         base = 1.0
-        if phase == MarketPhase.STRONG_EMERGENT:
-            base = 1.0 + 0.5 * conf
-        elif phase == MarketPhase.PROTO_EMERGENT:
-            base = 0.7 + 0.3 * conf
+        if phase is MarketPhase.STRONG_EMERGENT:
+            base = 1.0 + 0.5 * confidence
+        elif phase is MarketPhase.PROTO_EMERGENT:
+            base = 0.7 + 0.3 * confidence
         elif phase in (MarketPhase.TRANSITION, MarketPhase.CHAOTIC):
             base = 0.3
-        elif phase == MarketPhase.POST_EMERGENT:
+        elif phase is MarketPhase.POST_EMERGENT:
             base = 0.2
-        return float(np.clip(base * coh, 0.1, 2.0))
+        return float(np.clip(base * coherence, 0.1, 2.0))
 
-    def analyze(self, kres: MultiScaleResult, rres: TemporalRicciResult, static_ricci: float, ts: pd.Timestamp) -> CompositeSignal:
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def analyze(
+        self,
+        kres: MultiScaleResult,
+        rres: TemporalRicciResult,
+        static_ricci: float,
+        timestamp: pd.Timestamp,
+    ) -> CompositeSignal:
         R = float(kres.consensus_R)
-        coh = float(kres.cross_scale_coherence)
-        kt = float(rres.temporal_curvature)
-        trans = float(rres.topological_transition_score)
-        phase = self._phase(R, kt, trans, static_ricci)
-        conf = self._confidence(phase, coh, trans, R)
-        entry = self._entry(phase, R, kt, conf)
-        exit_u = self._exit(phase, trans, R)
-        risk = self._risk(phase, conf, coh)
+        coherence = float(kres.cross_scale_coherence)
+        temporal_ricci = float(rres.temporal_curvature)
+        transition = float(rres.topological_transition_score)
+        phase = self._phase(R, temporal_ricci, transition, static_ricci)
+        confidence = self._confidence(phase, coherence, transition, R)
+        entry = self._entry(phase, R, temporal_ricci, confidence)
+        exit_level = self._exit(phase, transition, R)
+        risk = self._risk(phase, confidence, coherence)
+        skipped = [tf.name for tf in getattr(kres, "skipped_timeframes", [])]
         return CompositeSignal(
-            phase=phase, confidence=conf, kuramoto_R=R, consensus_R=R,
-            cross_scale_coherence=coh, static_ricci=static_ricci, temporal_ricci=kt,
-            topological_transition=trans, entry_signal=entry, exit_signal=exit_u,
-            risk_multiplier=risk, dominant_timeframe_sec=kres.dominant_scale_sec, timestamp=ts
+            phase=phase,
+            confidence=confidence,
+            kuramoto_R=R,
+            consensus_R=R,
+            cross_scale_coherence=coherence,
+            static_ricci=float(static_ricci),
+            temporal_ricci=temporal_ricci,
+            topological_transition=transition,
+            entry_signal=entry,
+            exit_signal=exit_level,
+            risk_multiplier=risk,
+            dominant_timeframe_sec=kres.dominant_scale_sec,
+            timestamp=timestamp,
+            skipped_timeframes=skipped,
         )
 
-    def to_dict(self, s: CompositeSignal) -> Dict:
+    def to_dict(self, signal: CompositeSignal) -> Dict[str, object]:
         return {
-            "timestamp": s.timestamp, "phase": s.phase.value, "confidence": s.confidence,
-            "entry_signal": s.entry_signal, "exit_signal": s.exit_signal, "risk_multiplier": s.risk_multiplier,
-            "kuramoto_R": s.kuramoto_R, "consensus_R": s.consensus_R, "coherence": s.cross_scale_coherence,
-            "static_ricci": s.static_ricci, "temporal_ricci": s.temporal_ricci, "topological_transition": s.topological_transition,
-            "dominant_timeframe_sec": s.dominant_timeframe_sec
+            "timestamp": signal.timestamp,
+            "phase": signal.phase.value,
+            "confidence": signal.confidence,
+            "entry_signal": signal.entry_signal,
+            "exit_signal": signal.exit_signal,
+            "risk_multiplier": signal.risk_multiplier,
+            "kuramoto_R": signal.kuramoto_R,
+            "consensus_R": signal.consensus_R,
+            "coherence": signal.cross_scale_coherence,
+            "static_ricci": signal.static_ricci,
+            "temporal_ricci": signal.temporal_ricci,
+            "topological_transition": signal.topological_transition,
+            "dominant_timeframe_sec": signal.dominant_timeframe_sec,
+            "skipped_timeframes": signal.skipped_timeframes,
         }
 
+    # Legacy compatibility hooks used by unit tests
+    def _determine_phase(self, R: float, temporal_ricci: float, transition_score: float, static_ricci: float) -> MarketPhase:
+        return self._phase(R, temporal_ricci, transition_score, static_ricci)
+
+    def _compute_confidence(self, phase: MarketPhase, coherence: float, transition_score: float, R: float) -> float:
+        return self._confidence(phase, coherence, transition_score, R)
+
+    def _generate_entry_signal(
+        self,
+        phase: MarketPhase,
+        R: float,
+        temporal_ricci: float,
+        transition_score: float,
+        confidence: float,
+    ) -> float:
+        return self._entry(phase, R, temporal_ricci, confidence)
+
+    def _generate_exit_signal(self, phase: MarketPhase, transition_score: float, R: float) -> float:
+        return self._exit(phase, transition_score, R)
+
+    def _compute_risk_multiplier(self, phase: MarketPhase, confidence: float, coherence: float) -> float:
+        return self._risk(phase, confidence, coherence)
+
+
 class TradePulseCompositeEngine:
-    def __init__(self, kuramoto_config: Optional[Dict] = None, ricci_config: Optional[Dict] = None, composite_config: Optional[Dict] = None):
+    """High level helper orchestrating the full composite pipeline."""
+
+    def __init__(
+        self,
+        kuramoto_config: Optional[Dict] = None,
+        ricci_config: Optional[Dict] = None,
+        composite_config: Optional[Dict] = None,
+    ) -> None:
         self.k = MultiScaleKuramoto(**(kuramoto_config or {}))
         self.r = TemporalRicciAnalyzer(**(ricci_config or {}))
         self.c = KuramotoRicciComposite(**(composite_config or {}))
-        self.history: list[CompositeSignal] = []
+        self._history: list[CompositeSignal] = []
 
     def analyze_market(self, df: pd.DataFrame, price_col: str = "close", volume_col: str = "volume") -> CompositeSignal:
         kres = self.k.analyze(df, price_col=price_col)
         rres = self.r.analyze(df, price_col=price_col, volume_col=volume_col)
         static_ricci = rres.graph_snapshots[-1].avg_curvature if rres.graph_snapshots else 0.0
-        sig = self.c.analyze(kres, rres, static_ricci, df.index[-1])
-        self.history.append(sig)
-        return sig
+        signal = self.c.analyze(kres, rres, static_ricci, df.index[-1])
+        self._history.append(signal)
+        return signal
 
     def get_signal_dataframe(self) -> pd.DataFrame:
-        if not self.history: return pd.DataFrame()
-        return pd.DataFrame([self.c.to_dict(s) for s in self.history])
+        if not self._history:
+            return pd.DataFrame()
+        return pd.DataFrame([self.c.to_dict(sig) for sig in self._history])
+
+    @property
+    def signal_history(self) -> list[CompositeSignal]:
+        return list(self._history)

--- a/core/indicators/multiscale_kuramoto.py
+++ b/core/indicators/multiscale_kuramoto.py
@@ -1,155 +1,287 @@
+"""Multi-scale Kuramoto indicator utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from dataclasses import dataclass
-from typing import Dict, List, Tuple, Optional
 
-# -------------------- Lightweight Hilbert (no SciPy) --------------------
-def analytic_signal(x: np.ndarray) -> np.ndarray:
-    """
-    Compute analytic signal via FFT-based Hilbert transform.
-    Returns complex signal: x + i * H(x)
-    """
-    x = np.asarray(x, dtype=float)
-    N = x.size
-    X = np.fft.fft(x, n=N)
-    h = np.zeros(N)
-    if N % 2 == 0:
-        h[0] = 1.0
-        h[N//2] = 1.0
-        h[1:N//2] = 2.0
-    else:
-        h[0] = 1.0
-        h[1:(N+1)//2] = 2.0
-    xa = np.fft.ifft(X * h)
-    return xa
+from .base import BaseFeature, FeatureResult
+from .kuramoto import compute_phase
 
-def extract_phase(x: np.ndarray) -> np.ndarray:
-    """Detrend (simple linear) + analytic signal -> angle"""
-    x = np.asarray(x, dtype=float)
-    n = x.size
-    t = np.arange(n)
-    # simple linear detrend
-    A = np.vstack([t, np.ones(n)]).T
-    m, b = np.linalg.lstsq(A, x, rcond=None)[0]
-    detrended = x - (m*t + b)
-    z = analytic_signal(detrended)
-    return np.angle(z)
+try:  # SciPy is optional; fall back to a deterministic heuristic when missing.
+    from scipy import signal as _signal  # type: ignore
+except Exception:  # pragma: no cover - exercised in dedicated fallback test.
+    _signal = None
 
-# -------------------- Adaptive window via autocorrelation --------------------
-def dominant_period_autocorr(x: np.ndarray, min_window: int = 50, max_window: int = 500) -> int:
-    """
-    Estimate dominant period using (biased) autocorrelation peak.
-    """
-    x = np.asarray(x, dtype=float)
-    x = x - np.mean(x)
-    n = x.size
-    if n < min_window * 2:
-        return max(min_window, min(n//4, max_window))
 
-    # FFT-based autocorr
-    f = np.fft.fft(x, n=2*n)
-    ac = np.fft.ifft(f * np.conjugate(f)).real[:n]
-    ac = ac / ac[0] if ac[0] != 0 else ac
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+class TimeFrame(Enum):
+    """Supported timeframes expressed in seconds."""
 
-    # find first local maximum after lag 1
-    start = max(2, min_window//4)
-    end = min(n//2, max_window*2)
-    if end <= start+1:
-        return min_window
-    lag = start + np.argmax(ac[start:end])
-    win = int(np.clip(lag*2, min_window, max_window))
-    return win
+    M1 = 60
+    M5 = 300
+    M15 = 900
+    M30 = 1800
+    H1 = 3600
+    H4 = 14_400
+    D1 = 86_400
 
-# -------------------- Data models --------------------
-@dataclass
+    @property
+    def seconds(self) -> int:
+        return int(self.value)
+
+    @classmethod
+    def coerce(cls, value: Union["TimeFrame", int]) -> "TimeFrame":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, int):
+            for frame in cls:
+                if frame.value == value:
+                    return frame
+        raise ValueError(f"Unsupported timeframe value: {value!r}")
+
+
+@dataclass(slots=True)
 class KuramotoResult:
+    """Outcome of analysing a single timeframe."""
+
     R: float
     psi: float
     phases: np.ndarray
-    timeframe_sec: int
+    timeframe: TimeFrame
     window_size: int
 
-@dataclass
+
+@dataclass(slots=True)
 class MultiScaleResult:
+    """Collective summary produced by :class:`MultiScaleKuramoto`."""
+
     consensus_R: float
-    timeframe_results: Dict[int, KuramotoResult]
-    dominant_scale_sec: Optional[int]
+    timeframe_results: Mapping[TimeFrame, KuramotoResult]
+    dominant_scale: Optional[TimeFrame]
     cross_scale_coherence: float
     adaptive_window: int
+    skipped_timeframes: Sequence[TimeFrame]
 
-# -------------------- Core class --------------------
+    def as_dict(self) -> Dict[str, float | int | str | List[str]]:
+        ordered = dict(sorted(self.timeframe_results.items(), key=lambda kv: kv[0].value))
+        payload: Dict[str, float | int | str | List[str]] = {
+            "consensus_R": float(self.consensus_R),
+            "cross_scale_coherence": float(self.cross_scale_coherence),
+            "adaptive_window": int(self.adaptive_window),
+            "timeframes": [tf.name for tf in ordered],
+        }
+        if self.dominant_scale is not None:
+            payload["dominant_scale"] = self.dominant_scale.name
+        if self.skipped_timeframes:
+            payload["skipped_timeframes"] = [tf.name for tf in self.skipped_timeframes]
+        for tf, result in ordered.items():
+            payload[f"R_{tf.name}"] = float(result.R)
+            payload[f"psi_{tf.name}"] = float(result.psi)
+        return payload
+
+    @property
+    def dominant_scale_sec(self) -> Optional[int]:
+        return self.dominant_scale.seconds if self.dominant_scale is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Window selection
+# ---------------------------------------------------------------------------
+class WaveletWindowSelector:
+    """Adaptive window selection based on wavelet energy concentration."""
+
+    def __init__(self, *, min_window: int = 50, max_window: int = 500) -> None:
+        if min_window <= 0 or max_window <= 0:
+            raise ValueError("Window bounds must be positive")
+        if min_window >= max_window:
+            raise ValueError("min_window must be strictly less than max_window")
+        self.min_window = int(min_window)
+        self.max_window = int(max_window)
+
+    def select_window(self, prices: Sequence[float]) -> int:
+        series = np.asarray(prices, dtype=float)
+        if series.ndim != 1:
+            raise ValueError("prices must be one-dimensional")
+        if series.size < self.min_window:
+            return self.min_window
+
+        if _signal is None:
+            return int(np.sqrt(self.min_window * self.max_window))
+
+        widths = np.arange(max(1, self.min_window // 4), max(2, self.max_window // 4))
+        cwt_matrix = _signal.cwt(series - series.mean(), _signal.morlet2, widths)
+        power = np.abs(cwt_matrix) ** 2
+        idx = int(np.argmax(power.mean(axis=1)))
+        optimal = int(widths[idx] * 2)
+        return int(np.clip(optimal, self.min_window, self.max_window))
+
+
+# ---------------------------------------------------------------------------
+# Core analyser
+# ---------------------------------------------------------------------------
 class MultiScaleKuramoto:
-    """
-    Multi-scale Kuramoto analysis with zero external deps (NumPy/Pandas only).
-    timeframes: list of seconds (e.g., [60, 300, 900, 3600])
-    """
-    def __init__(self, timeframes: Optional[List[int]] = None, use_adaptive_window: bool = True, base_window: int = 200):
-        self.timeframes = timeframes or [60, 300, 900, 3600]
-        self.use_adaptive_window = use_adaptive_window
-        self.base_window = base_window
+    """Kuramoto order parameter computed across multiple timeframes."""
+
+    def __init__(
+        self,
+        timeframes: Optional[Iterable[Union[TimeFrame, int]]] = None,
+        *,
+        use_adaptive_window: bool = True,
+        base_window: int = 200,
+        window_selector: Optional[WaveletWindowSelector] = None,
+    ) -> None:
+        frames = tuple(TimeFrame.coerce(tf) for tf in (timeframes or (TimeFrame.M1, TimeFrame.M5, TimeFrame.M15, TimeFrame.H1)))
+        if not frames:
+            raise ValueError("At least one timeframe must be provided")
+        if base_window <= 0:
+            raise ValueError("base_window must be positive")
+        self.timeframes: tuple[TimeFrame, ...] = frames
+        self.use_adaptive_window = bool(use_adaptive_window)
+        self.base_window = int(base_window)
+        self.window_selector = window_selector or WaveletWindowSelector()
+
+    def analyze(self, df: pd.DataFrame, *, price_col: str = "close") -> MultiScaleResult:
+        if price_col not in df.columns:
+            raise KeyError(f"Column '{price_col}' not found in dataframe")
+        if df.empty:
+            raise ValueError("Dataframe cannot be empty")
+
+        prices = df[price_col].astype(float)
+        if not isinstance(prices.index, pd.DatetimeIndex):
+            prices = prices.copy()
+            prices.index = pd.to_datetime(prices.index)
+
+        window = self._select_window(prices.values)
+
+        timeframe_results: MutableMapping[TimeFrame, KuramotoResult] = {}
+        for timeframe in self.timeframes:
+            series = self._resample(prices, timeframe)
+            if series.size < max(window, 8):
+                continue
+            timeframe_results[timeframe] = self._analyze_timeframe(series.values, timeframe, window)
+
+        consensus = self._compute_consensus(timeframe_results)
+        dominant = self._dominant_scale(timeframe_results)
+        coherence = self._cross_scale_coherence(timeframe_results)
+        skipped = [tf for tf in self.timeframes if tf not in timeframe_results]
+        return MultiScaleResult(
+            consensus_R=consensus,
+            timeframe_results=dict(timeframe_results),
+            dominant_scale=dominant,
+            cross_scale_coherence=coherence,
+            adaptive_window=window,
+            skipped_timeframes=tuple(skipped),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _select_window(self, prices: np.ndarray) -> int:
+        if not self.use_adaptive_window:
+            return self.base_window
+        return int(self.window_selector.select_window(prices))
+
+    def _resample(self, prices: pd.Series, timeframe: TimeFrame) -> pd.Series:
+        rule = f"{timeframe.seconds}s"
+        resampled = prices.resample(rule).last().dropna()
+        if resampled.empty:
+            return prices.iloc[[-1]]
+        return resampled
+
+    def _analyze_timeframe(self, prices: np.ndarray, timeframe: TimeFrame, window: int) -> KuramotoResult:
+        phases = compute_phase(prices)
+        if phases.size < window:
+            window = max(1, phases.size)
+        r_values: List[float] = []
+        psi_values: List[float] = []
+        for end in range(window, phases.size + 1):
+            segment = phases[end - window : end]
+            R, psi = self._kuramoto_order_parameter(segment)
+            r_values.append(R)
+            psi_values.append(psi)
+        R_current = r_values[-1] if r_values else 0.0
+        psi_current = psi_values[-1] if psi_values else 0.0
+        return KuramotoResult(R=R_current, psi=psi_current, phases=phases, timeframe=timeframe, window_size=window)
 
     @staticmethod
-    def _kuramoto(phases: np.ndarray) -> Tuple[float, float]:
-        z = np.exp(1j * phases).mean()
-        return float(np.abs(z)), float(np.angle(z))
+    def _kuramoto_order_parameter(phases: np.ndarray) -> Tuple[float, float]:
+        values = np.asarray(phases, dtype=float)
+        if values.size == 0:
+            return 0.0, 0.0
+        complex_order = np.mean(np.exp(1j * values))
+        R = float(np.clip(np.abs(complex_order), 0.0, 1.0))
+        psi = float(np.angle(complex_order))
+        return R, psi
 
-    def _resample_close(self, df: pd.DataFrame, tf_sec: int, price_col: str) -> pd.Series:
-        if not isinstance(df.index, pd.DatetimeIndex):
-            df = df.copy()
-            df.index = pd.to_datetime(df.index)
-        return df[price_col].resample(f"{tf_sec}S").last().dropna()
-
-    def analyze_single_timeframe(self, prices: np.ndarray, tf_sec: int, window: int) -> KuramotoResult:
-        phases = extract_phase(prices)
-        R_vals = []
-        psi_vals = []
-        for i in range(window, len(phases)):
-            R, psi = self._kuramoto(phases[i-window:i])
-            R_vals.append(R); psi_vals.append(psi)
-        R_cur = R_vals[-1] if R_vals else 0.0
-        psi_cur = psi_vals[-1] if psi_vals else 0.0
-        return KuramotoResult(R=R_cur, psi=psi_cur, phases=phases, timeframe_sec=tf_sec, window_size=window)
-
-    def _consensus(self, results: Dict[int, KuramotoResult]) -> float:
+    def _compute_consensus(self, results: Mapping[TimeFrame, KuramotoResult]) -> float:
         if not results:
             return 0.0
-        # weights favor higher timeframes
-        weights = {60:0.1, 300:0.2, 900:0.3, 3600:0.4}
-        ws, vs = [], []
-        for tf, res in results.items():
-            w = weights.get(tf, 0.25)
-            ws.append(w); vs.append(res.R)
-        ws = np.asarray(ws); vs = np.asarray(vs)
-        return float((ws*vs).sum() / ws.sum())
+        weights = {
+            TimeFrame.M1: 0.1,
+            TimeFrame.M5: 0.2,
+            TimeFrame.M15: 0.3,
+            TimeFrame.H1: 0.4,
+        }
+        weighted_sum = 0.0
+        total_weight = 0.0
+        for timeframe, result in results.items():
+            weight = weights.get(timeframe, 1.0 / max(1, len(results)))
+            weighted_sum += weight * result.R
+            total_weight += weight
+        return float(weighted_sum / total_weight) if total_weight else 0.0
 
-    def _dominant(self, results: Dict[int, KuramotoResult]) -> Optional[int]:
-        if not results: return None
-        return max(results.items(), key=lambda kv: kv[1].R)[0]
+    def _dominant_scale(self, results: Mapping[TimeFrame, KuramotoResult]) -> Optional[TimeFrame]:
+        if not results:
+            return None
+        return max(results.items(), key=lambda item: item[1].R)[0]
 
-    def _coherence(self, results: Dict[int, KuramotoResult]) -> float:
-        if len(results) < 2: return 1.0
-        arr = np.array([r.R for r in results.values()], dtype=float)
-        mean = arr.mean()
-        if mean == 0: return 0.0
-        cv = arr.std() / mean
+    def _cross_scale_coherence(self, results: Mapping[TimeFrame, KuramotoResult]) -> float:
+        if len(results) < 2:
+            return 1.0 if results else 0.0
+        values = np.array([res.R for res in results.values()], dtype=float)
+        mean = float(values.mean())
+        if mean == 0.0:
+            return 0.0
+        std = float(values.std())
+        cv = std / mean
         return float(np.exp(-cv))
 
-    def analyze(self, df: pd.DataFrame, price_col: str = "close") -> MultiScaleResult:
-        if df.empty or price_col not in df.columns:
-            raise ValueError("DataFrame must contain a 'close' column and not be empty")
 
-        prices = df[price_col].astype(float).values
-        window = dominant_period_autocorr(prices) if self.use_adaptive_window else self.base_window
+# ---------------------------------------------------------------------------
+# Feature adapter
+# ---------------------------------------------------------------------------
+class MultiScaleKuramotoFeature(BaseFeature):
+    """Expose the multi-scale Kuramoto consensus as a feature."""
 
-        tf_results: Dict[int, KuramotoResult] = {}
-        for tf in self.timeframes:
-            s = self._resample_close(df, tf, price_col)
-            if len(s) < window + 5:  # need enough data
-                continue
-            tf_results[tf] = self.analyze_single_timeframe(s.values, tf, window)
+    def __init__(
+        self,
+        analyzer: Optional[MultiScaleKuramoto] = None,
+        *,
+        name: str | None = None,
+        price_col: str = "close",
+    ) -> None:
+        super().__init__(name or "multiscale_kuramoto")
+        self.analyzer = analyzer or MultiScaleKuramoto()
+        self.price_col = price_col
 
-        consensus = self._consensus(tf_results)
-        dom = self._dominant(tf_results)
-        coh = self._coherence(tf_results)
-        return MultiScaleResult(consensus_R=consensus, timeframe_results=tf_results, dominant_scale_sec=dom, cross_scale_coherence=coh, adaptive_window=window)
+    def transform(self, data: pd.DataFrame, **_: object) -> FeatureResult:
+        result = self.analyzer.analyze(data, price_col=self.price_col)
+        metadata = result.as_dict()
+        return FeatureResult(name=self.name, value=result.consensus_R, metadata=metadata)
+
+
+__all__ = [
+    "KuramotoResult",
+    "MultiScaleKuramoto",
+    "MultiScaleKuramotoFeature",
+    "MultiScaleResult",
+    "TimeFrame",
+    "WaveletWindowSelector",
+]

--- a/tests/property/test_invariants.py
+++ b/tests/property/test_invariants.py
@@ -1,254 +1,51 @@
-# TradePulse: Kuramoto-Ricci Composite Configuration
-# Location: configs/kuramoto_ricci_composite.yaml
+"""Basic invariants for the Kuramoto–Ricci composite configuration."""
 
-# Multi-Scale Kuramoto Configuration
-kuramoto:
-  # Timeframes for multi-scale analysis (in seconds)
-  timeframes:
-    - 60      # 1 minute
-    - 300     # 5 minutes
-    - 900     # 15 minutes
-    - 3600    # 1 hour
-  
-  # Adaptive window settings
-  adaptive_window:
-    enabled: true
-    min_window: 50
-    max_window: 500
-    base_window: 200  # Used when adaptive is disabled
-  
-  # Consensus weights (must sum to 1.0)
-  consensus_weights:
-    M1: 0.1    # 1 minute
-    M5: 0.2    # 5 minutes
-    M15: 0.3   # 15 minutes
-    H1: 0.4    # 1 hour
-  
-  # Phase extraction
-  hilbert:
-    detrend: true
-    method: "linear"  # linear, constant, or none
+from __future__ import annotations
 
-# Temporal Ricci Configuration
-ricci:
-  # Graph construction
-  graph:
-    n_levels: 20              # Number of price levels for graph nodes
-    connection_threshold: 0.1  # Minimum weight for edge creation
-  
-  # Temporal analysis
-  temporal:
-    window_size: 100           # Window for each snapshot
-    n_snapshots: 10            # Number of snapshots to track
-    snapshot_interval: null    # Auto-calculated if null
-  
-  # Ollivier-Ricci parameters
-  ollivier:
-    alpha: 0.5                 # Lazy random walk parameter [0, 1]
-    timeout: 1                 # Graph edit distance timeout (seconds)
-  
-  # Topological transition detection
-  transition:
-    derivative_window: 2       # Window for computing metric changes
-    jump_threshold: 0.3        # Threshold for transition detection
-    sigmoid_steepness: 10      # Steepness of sigmoid function
+from pathlib import Path
 
-# Composite Indicator Configuration
-composite:
-  # Phase determination thresholds
-  thresholds:
-    # Kuramoto thresholds
-    R_strong_emergent: 0.80     # Strong emergent phase threshold
-    R_proto_emergent: 0.40      # Proto emergent phase threshold
-    coherence_min: 0.60         # Minimum cross-scale coherence
-    
-    # Ricci thresholds
-    ricci_negative: -0.30       # Negative curvature threshold
-    temporal_ricci: -0.20       # Temporal curvature threshold
-    
-    # Transition threshold
-    topological_transition: 0.70  # High transition probability
-  
-  # Signal generation
-  signals:
-    min_confidence: 0.50        # Minimum confidence for entry signals
-    confidence_boost:
-      strong_emergent: 1.5      # Multiplier for strong emergent
-      chaotic: 0.5              # Multiplier for chaotic
-    
-    # Risk multipliers
-    risk_multipliers:
-      strong_emergent:
-        base: 1.0
-        confidence_scale: 0.5   # Additional scaling by confidence
-      proto_emergent:
-        base: 0.7
-        confidence_scale: 0.3
-      transition: 0.3
-      chaotic: 0.3
-      post_emergent: 0.2
-      
-      # Global limits
-      min: 0.1
-      max: 2.0
-  
-  # Phase-specific behavior
-  phases:
-    strong_emergent:
-      entry_direction: "temporal_ricci"  # Use temporal_ricci for direction
-      exit_urgency: 0.1
-      
-    proto_emergent:
-      entry_scale: 0.5
-      exit_urgency: 0.3
-      
-    post_emergent:
-      entry_signal: -0.3         # Mild short bias
-      exit_urgency: 0.7
-      
-    transition:
-      entry_signal: 0.0          # No entry during transition
-      exit_urgency: "transition_score"  # Use transition score
-      
-    chaotic:
-      entry_signal: 0.0          # Stay out
-      exit_urgency: 0.5
+import yaml
 
-# Integration Settings
-integration:
-  # Data requirements
-  data:
-    min_history: 1000           # Minimum data points required
-    required_columns:
-      - close
-      - volume
-    datetime_index: true
-  
-  # Performance
-  performance:
-    parallel_timeframes: true   # Compute timeframes in parallel
-    cache_graphs: true          # Cache graph snapshots
-    max_cache_size: 100
-  
-  # Logging
-  logging:
-    level: "INFO"              # DEBUG, INFO, WARNING, ERROR
-    log_signals: true
-    log_metrics: true
-    save_history: true
-    history_path: "outputs/signal_history.csv"
+CONFIG_PATH = Path("configs/kuramoto_ricci_composite.yaml")
 
-# Backtesting Integration
-backtest:
-  # Signal-to-trade conversion
-  trade_execution:
-    entry_signal_threshold: 0.3   # Minimum entry signal to trade
-    exit_signal_threshold: 0.6    # Minimum exit signal to close
-    
-  # Position sizing
-  position_sizing:
-    base_size: 1.0                # Base position size
-    use_risk_multiplier: true     # Use composite risk multiplier
-    max_position: 2.0             # Maximum position size
-    
-  # Risk management
-  risk:
-    use_confidence_filter: true   # Filter trades by confidence
-    min_confidence: 0.5
-    stop_loss_multiplier: 1.5     # SL based on risk_multiplier
-    take_profit_multiplier: 2.0
 
-# Monitoring & Alerts
-monitoring:
-  alerts:
-    # Phase change alerts
-    phase_change:
-      enabled: true
-      notify_on:
-        - STRONG_EMERGENT
-        - TRANSITION
-    
-    # Metric alerts
-    metric_thresholds:
-      high_transition:
-        metric: "topological_transition_score"
-        threshold: 0.8
-        action: "log"
-      
-      low_coherence:
-        metric: "cross_scale_coherence"
-        threshold: 0.3
-        action: "log"
-      
-      extreme_risk:
-        metric: "risk_multiplier"
-        min: 0.1
-        max: 1.8
-        action: "alert"
-  
-  # Dashboard updates
-  dashboard:
-    update_interval: 60         # Seconds
-    metrics_to_display:
-      - kuramoto_R
-      - consensus_R
-      - temporal_ricci
-      - topological_transition
-      - phase
-      - confidence
-      - entry_signal
-      - exit_signal
+def load_config() -> dict:
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
 
-# Feature Engineering (for ML integration)
-features:
-  # Derived features from composite
-  engineering:
-    kuramoto_features:
-      - consensus_R
-      - cross_scale_coherence
-      - dominant_timeframe_R
-      
-    ricci_features:
-      - static_ricci
-      - temporal_ricci
-      - topological_transition_score
-      - structural_stability
-      - edge_persistence
-    
-    composite_features:
-      - phase_encoded          # One-hot encoding of phase
-      - confidence
-      - entry_signal
-      - exit_signal
-      - risk_multiplier
-  
-  # Feature normalization
-  normalization:
-    method: "robust"           # standard, minmax, robust
-    rolling_window: 500
 
-# Experimental Settings
-experimental:
-  # Advanced Kuramoto
-  kuramoto_extensions:
-    higher_order_coupling: false     # Triplet interactions
-    adaptive_coupling_strength: false # Dynamic coupling
-    
-  # Advanced Ricci
-  ricci_extensions:
-    persistent_homology: false       # TDA integration
-    ricci_flow: false                # Graph evolution via flow
-    
-  # Meta-learning
-  meta_learning:
-    enabled: false
-    update_thresholds: false         # Adaptive threshold learning
-    strategy_evolution: false        # Genetic programming
+def test_kuramoto_timeframes_are_increasing() -> None:
+    config = load_config()
+    frames = config["kuramoto"]["timeframes"]
+    assert all(isinstance(value, int) and value > 0 for value in frames)
+    assert frames == sorted(frames)
 
-# Version & Metadata
-metadata:
-  version: "1.0.0"
-  author: "TradePulse Development"
-  description: "Kuramoto-Ricci Composite Indicator Configuration"
-  created: "2024-10-06"
-  last_modified: "2024-10-06"
+
+def test_adaptive_window_bounds() -> None:
+    config = load_config()
+    adaptive = config["kuramoto"].get("adaptive_window", {})
+    assert adaptive.get("enabled", True) is True
+    assert adaptive.get("min_window", 0) < adaptive.get("max_window", 0)
+    assert adaptive.get("base_window", 0) >= adaptive.get("min_window", 0)
+
+
+def test_temporal_ricci_parameters_valid() -> None:
+    config = load_config()
+    temporal = config["ricci"]["temporal"]
+    assert temporal["window_size"] > 0
+    assert 2 <= temporal["n_snapshots"] <= 32
+
+
+def test_composite_thresholds_are_ordered() -> None:
+    config = load_config()
+    thresholds = config["composite"]["thresholds"]
+    assert 0.0 < thresholds["R_proto_emergent"] < thresholds["R_strong_emergent"] <= 1.0
+    assert thresholds["coherence_min"] <= thresholds["R_strong_emergent"]
+    assert thresholds["ricci_negative"] < 0 < thresholds["topological_transition"] <= 1.0
+    assert thresholds["temporal_ricci"] < 0
+
+
+def test_signal_confidence_is_probabilistic() -> None:
+    config = load_config()
+    min_confidence = config["composite"]["signals"]["min_confidence"]
+    assert 0.0 <= min_confidence <= 1.0


### PR DESCRIPTION
## Summary
- restore the lightweight multi-scale Kuramoto analyzer and feature metadata based on the original TimeFrame enum
- revert the Kuramoto–Ricci composite, temporal Ricci analyzer, and related helpers to the pragmatic baseline implementations
- drop the generated technical debt report and align the configuration and property tests with the restored defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4f07e3a748329801313fb60344067