### PR TITLE
Add release readiness assessment report

### DIFF
--- a/reports/release_readiness.md
+++ b/reports/release_readiness.md
@@ -1,0 +1,26 @@
+# Release Readiness Assessment
+
+## Executive Summary
+TradePulse provides a functional core for algorithmic trading — including indicator computation, a walk-forward backtester, and a CLI that links indicators to execution workflows — but the project is **not yet ready for a production-grade release**. Several critical gaps remain: the automated test suite fails on a clean checkout because required dependencies are missing, coverage is well below the documented target, operations documentation referenced in the README is absent, and the web dashboard is still a placeholder. Addressing these issues should precede any public launch.
+
+## Evidence of Maturity
+- **Cohesive CLI workflow.** The CLI combines geometric indicators, entropy metrics, Ricci curvature, backtesting, and live CSV streaming into actionable commands for analyze/backtest/live modes, demonstrating an integrated pipeline from data to signals. 【F:interfaces/cli.py†L1-L135】
+- **Deterministic backtesting engine.** The vectorised walk-forward engine already calculates P&L, drawdowns, and trade counts with guard rails on input validation. 【F:backtest/engine.py†L1-L35】
+- **Documented architecture and monitoring practices.** High-level docs describe modular boundaries and provide observability guidelines, supporting future operations work. 【F:README.md†L134-L155】【F:docs/monitoring.md†L1-L158】
+
+## Release Blockers
+- **Automated tests fail out-of-the-box.** `pytest` aborts because the property-based suite requires PyYAML, which is neither vendored nor listed in the default requirements, causing an ImportError before tests run. 【5d57c7†L1-L16】【F:interfaces/cli.py†L36-L48】【F:requirements.txt†L1-L7】
+- **Coverage far below target.** The README advertises only 56 % coverage while the stated target is 98 %, indicating major untested paths relative to expectations. 【F:README.md†L101-L130】
+- **Missing referenced documentation.** The README links to `docs/deployment.md` and `docs/installation.md`, but these files are absent, leaving installation and deployment instructions incomplete. 【F:README.md†L72-L99】【440232†L1-L4】
+- **Frontend still a stub.** The Next.js dashboard consists of a single placeholder string, so there is no production-ready UI. 【F:apps/web/app/page.tsx†L1-L3】
+
+## Additional Gaps to Address
+- **Dependency hygiene.** Property-based tests also skip because Hypothesis is optional unless `requirements-dev` is installed. Either update documentation to clarify workflows or consolidate runtime/test dependencies. 【5d57c7†L1-L16】【F:requirements-dev.txt†L1-L9】
+- **Operational parity.** Several documentation promises (e.g., protocol buffer interfaces, microservice engines) lack corresponding implementation or deployment guides in the repo snapshot, suggesting marketing material outpaces available code. 【F:README.md†L49-L155】
+
+## Recommendations
+1. Fix the dependency manifest (add PyYAML to `requirements.txt` or gate YAML usage) and ensure `pytest` passes on a clean environment; enforce this in CI.
+2. Prioritise test coverage improvements toward the advertised 98 % goal, focusing on critical trading logic and risk modules.
+3. Restore or write the missing installation/deployment documentation so onboarding and operations match README promises.
+4. Flesh out the web dashboard or mark it experimental to set accurate user expectations.
+5. Reconcile README claims with implemented services to avoid misaligned release notes.


### PR DESCRIPTION
## Summary
- add a release readiness assessment summarising the current state of the project
- document key strengths, blockers, and recommendations before shipping a production release

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68e68a00898883299b83c587febfb8be