### PR TITLE
Improve strategy simulation data hygiene

### DIFF
--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -256,11 +256,22 @@ class TestNumericalStability:
         
         try:
             score = strategy.simulate_performance(df)
-            # May return finite or nan/inf depending on implementation
-            assert isinstance(score, float)
+            assert np.isfinite(score)
         except (ValueError, TypeError, OverflowError):
             # Acceptable to raise error for invalid data
             pass
+
+    def test_strategy_returns_zero_for_all_missing_prices(self) -> None:
+        """Strategy should fail gracefully when all prices are missing."""
+        strategy = Strategy(name="missing", params={})
+        df = pd.DataFrame({"close": [np.nan, np.nan, np.nan]})
+
+        score = strategy.simulate_performance(df)
+
+        assert score == 0.0
+        assert strategy.params["last_equity_curve"] == []
+        assert strategy.params["max_drawdown"] == 0.0
+        assert strategy.params["trades"] == 0
 
     def test_entropy_handles_negative_values(self) -> None:
         """Entropy should handle negative values in data."""


### PR DESCRIPTION
## Summary
- sanitize price inputs in `Strategy.simulate_performance` to handle NaN/inf data and duplicate timestamps
- update diagnostics bookkeeping and z-score calculation to work with short or empty return windows
- tighten edge case tests to require finite scores and cover all-missing price scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6955351b483299cfd52fc6fb3eb32